### PR TITLE
Fix CI builds after upstream documentation changes

### DIFF
--- a/scripts/buildNeuron.sh
+++ b/scripts/buildNeuron.sh
@@ -45,18 +45,4 @@ echo "------- Install NEURON -------"
 make install
 
 echo "------- Run test suite -------"
-# Make sure the installed files can be found when executing the tests
-export PATH=${INSTALL_DIR}/bin:${PATH}
-# On some platforms (RedHat) then the lib64 prefix will be used for the
-# compiled parts of the NEURON Python package. On other platforms then
-# everything will be under lib/python.
-NRNPYTHONLIB64="${INSTALL_DIR}/lib64/python"
-if [ -f "${NRNPYTHONLIB64}/neuron/__init__.py" ]; then
-  # Avoid adding a trailing : if PYTHONPATH was empty
-  export PYTHONPATH="${NRNPYTHONLIB64}${PYTHONPATH+":"}${PYTHONPATH-}"
-fi
-# Avoid adding a trailing : if PYTHONPATH was empty
-export PYTHONPATH="${INSTALL_DIR}/lib/python${PYTHONPATH+":"}${PYTHONPATH-}"
-
-# Run tests
 ctest -VV

--- a/scripts/install_debian.sh
+++ b/scripts/install_debian.sh
@@ -8,6 +8,6 @@ export DEBIAN_FRONTEND=noninteractive
 # --- End GitHub-Actions-specific code ---
 # ---
 apt-get update
-apt-get install -y bison cmake doxygen flex git libncurses-dev libopenmpi-dev \
+apt-get install -y bison cmake flex git libncurses-dev libopenmpi-dev \
   libx11-dev libxcomposite-dev openmpi-bin python3-numpy python3-pip \
   python3-setuptools python3-venv python3-wheel sudo

--- a/scripts/install_macOS.sh
+++ b/scripts/install_macOS.sh
@@ -1,4 +1,4 @@
-brew install coreutils doxygen mpich xz
+brew install coreutils mpich xz
 brew unlink mpich
 brew install openmpi
 brew install --cask xquartz

--- a/scripts/install_redhat.sh
+++ b/scripts/install_redhat.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Use DNF if available (not CentOS7), otherwise YUM
 CMD=$(command -v dnf || command -v yum)
-${CMD} install -y bison cmake dnf doxygen flex gcc gcc-c++ git \
+${CMD} install -y bison cmake dnf flex gcc gcc-c++ git \
   openmpi-devel libXcomposite-devel libXext-devel make ncurses-devel \
   python3-devel python3-pip python3-wheel sudo which

--- a/scripts/install_redhat_centos:8.sh
+++ b/scripts/install_redhat_centos:8.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-# This repository is needed to get Doxygen in CentOS8
-dnf install -y 'dnf-command(config-manager)'
-dnf config-manager --set-enabled powertools


### PR DESCRIPTION
Upstream changes in NEURON caused `make docs` to execute several IPython
notebooks, which exposed two problems with the environment setup in this
repository.
- Upgrade pip before installing packages using it. Old pip did not
  manage to resolve the required numpy version correctly on Debian.
- On RedHat systems NEURON installs files to both
  ${INSTALL_DIR}/lib/python and ${INSTALL_DIR}/lib64/python, but the
  latter was not added to PYTHONPATH. Also avoid adding a trailing colon
  if PYTHONPATH was empty.

The IPython notebook execution is quite slow and sometimes hits resource
limits in the GitHub Actions runners, so in fact we disable this by
replacing `make docs` with `make doxygen` and `make sphinx`.