### PR TITLE
Install pytest-cov

### DIFF
--- a/scripts/buildNeuron.sh
+++ b/scripts/buildNeuron.sh
@@ -13,7 +13,7 @@ export PYTHON=$(command -v python3)
 # correctly
 ${PYTHON} -m pip install --user --upgrade pip
 ${PYTHON} -m pip install --user --upgrade bokeh cython ipython matplotlib \
-  mpi4py pytest scikit-build
+  mpi4py pytest pytest-cov scikit-build
 
 # Set default compilers, but don't override preset values
 export CC=${CC:-gcc}


### PR DESCRIPTION
https://github.com/neuronsimulator/nrn/pull/962 added a dependency on `pytest-cov`.

@alexsavulescu @pramodk do you think we should integrate this repository into the main https://github.com/neuronsimulator/nrn one to help catch such issues earlier?