### PR TITLE
Install diffutils on RedHat systems

### DIFF
--- a/scripts/install_redhat.sh
+++ b/scripts/install_redhat.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Use DNF if available (not CentOS7), otherwise YUM
 CMD=$(command -v dnf || command -v yum)
-${CMD} install -y bison cmake dnf flex gcc gcc-c++ git \
+${CMD} install -y bison cmake diffutils dnf flex gcc gcc-c++ git \
   openmpi-devel libXcomposite-devel libXext-devel make ncurses-devel \
   python3-devel python3-pip python3-wheel sudo which


### PR DESCRIPTION
This fixes recent failures in the CentOS8 and Fedora 32 builds.