### PR TITLE
Use Ninja instead of Unix Makefiles.

### DIFF
--- a/scripts/buildNeuron.sh
+++ b/scripts/buildNeuron.sh
@@ -31,11 +31,11 @@ cmake --version
 ${PYTHON} -c 'import os, sys; os.set_blocking(sys.stdout.fileno(), True)'
 
 echo "------- Configuring NEURON -------"
-export CMAKE_OPTION="-DNRN_ENABLE_BINARY_SPECIAL=ON -DNRN_ENABLE_MPI=ON \
- -DNRN_ENABLE_INTERVIEWS=ON -DNRN_ENABLE_CORENEURON=ON \
- -DPYTHON_EXECUTABLE=${PYTHON} -DCMAKE_C_COMPILER=${CC} \
- -DCMAKE_CXX_COMPILER=${CXX} -DNRN_ENABLE_TESTS=ON \
- -DCMAKE_INSTALL_PREFIX=${INSTALL_DIR}"
+export CMAKE_OPTION="-G Ninja -DNRN_ENABLE_BINARY_SPECIAL=ON \
+ -DNRN_ENABLE_MPI=ON -DNRN_ENABLE_INTERVIEWS=ON \
+ -DNRN_ENABLE_CORENEURON=ON -DPYTHON_EXECUTABLE=${PYTHON} \
+ -DCMAKE_C_COMPILER=${CC} -DCMAKE_CXX_COMPILER=${CXX} \
+ -DNRN_ENABLE_TESTS=ON -DCMAKE_INSTALL_PREFIX=${INSTALL_DIR}"
 echo "CMake options: ${CMAKE_OPTION}"
 mkdir build && cd build
 cmake ${CMAKE_OPTION} ..
@@ -53,7 +53,7 @@ fi
 cmake --build . -- -j ${PARALLEL_JOBS}
 
 echo "------- Install NEURON -------"
-make install
+cmake --build . -- install
 
 echo "------- Run test suite -------"
 ctest -VV -j ${PARALLEL_JOBS}

--- a/scripts/install_debian.sh
+++ b/scripts/install_debian.sh
@@ -9,5 +9,5 @@ export DEBIAN_FRONTEND=noninteractive
 # ---
 apt-get update
 apt-get install -y bison cmake flex git libncurses-dev libopenmpi-dev \
-  libx11-dev libxcomposite-dev openmpi-bin python3-numpy python3-pip \
-  python3-setuptools python3-venv python3-wheel sudo
+  libx11-dev libxcomposite-dev ninja-build openmpi-bin python3-numpy \
+  python3-pip python3-setuptools python3-venv python3-wheel sudo

--- a/scripts/install_macOS.sh
+++ b/scripts/install_macOS.sh
@@ -1,4 +1,4 @@
-brew install coreutils mpich xz
+brew install coreutils mpich ninja xz
 brew unlink mpich
 brew install openmpi
 brew install --cask xquartz

--- a/scripts/install_redhat.sh
+++ b/scripts/install_redhat.sh
@@ -3,4 +3,4 @@
 CMD=$(command -v dnf || command -v yum)
 ${CMD} install -y bison cmake diffutils dnf flex gcc gcc-c++ git \
   openmpi-devel libXcomposite-devel libXext-devel make ncurses-devel \
-  python3-devel python3-pip python3-wheel sudo which
+  ninja-build python3-devel python3-pip python3-wheel sudo which

--- a/scripts/install_redhat_centos:8.sh
+++ b/scripts/install_redhat_centos:8.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# Enable the (official) PowerTools repository. This provides Ninja.
+dnf install -y dnf-plugins-core
+dnf config-manager --set-enabled powertools


### PR DESCRIPTION
Ninja is faster (and better) than `make`, so this both makes the CI a little more efficient and is a (tiny) step towards encouraging people to use Ninja.