### PR TITLE
Use MPICH instead of OpenMPI in some cases.

### DIFF
--- a/scripts/install_debian.sh
+++ b/scripts/install_debian.sh
@@ -8,6 +8,6 @@ export DEBIAN_FRONTEND=noninteractive
 # --- End GitHub-Actions-specific code ---
 # ---
 apt-get update
-apt-get install -y bison cmake flex git libncurses-dev libopenmpi-dev \
-  libx11-dev libxcomposite-dev ninja-build openmpi-bin python3-numpy \
+apt-get install -y bison cmake flex git libncurses-dev libmpich-dev \
+  libx11-dev libxcomposite-dev ninja-build mpich python3-numpy \
   python3-pip python3-setuptools python3-venv python3-wheel sudo


### PR DESCRIPTION
https://github.com/neuronsimulator/nrn/issues/1045 tracks the issue that the `debian:stable` build in this repository is rather prone to hanging. This can happen in either the CTest suite or the wheel test.

So far this has not been reproduced locally, so it is not obvious how to solve it. This PR changes the Debian and Ubuntu builds to use MPICH instead of OpenMPI, to see if this has any impact on how often the jobs hang.