### PR TITLE
Test the latest NEURON release; only on Mondays.

### DIFF
--- a/.github/workflows/build-neuron.yml
+++ b/.github/workflows/build-neuron.yml
@@ -23,9 +23,8 @@ jobs:
         repository: neuronsimulator/nrn
     - id: provide_versions
       run: |
-        # To enable this feature after v8.0.0 is released, change 8 to 7 (for
-        # example) so the latest release is tested every Sunday (for example)
-        if [ $(date +%u) -eq 8 ]
+        # Test the latest release on Mondays.
+        if [ $(date +%u) -eq 1 ]
         then
           echo "::set-output name=matrix::[\"\", \"${{steps.get_latest_release.outputs.release }}\"]"
         else


### PR DESCRIPTION
Closes #2 by enabling test builds of the latest release (currently v8.0.0).

At present these are only enabled:
```bash
if [ $(date +%u) -eq 1 ]
```
i.e. only on Mondays, which seemed like a reasonable compromise between wasting resources and missing issues that emerge.