### PR TITLE
Update RedHat distributions before installing.

### DIFF
--- a/scripts/install_redhat.sh
+++ b/scripts/install_redhat.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # Use DNF if available (not CentOS7), otherwise YUM
 CMD=$(command -v dnf || command -v yum)
+${CMD} update -y
 ${CMD} install -y bison cmake diffutils dnf flex gcc gcc-c++ git \
   openmpi-devel libXcomposite-devel libXext-devel make ncurses-devel \
   ninja-build python3-devel python3-pip python3-wheel sudo which


### PR DESCRIPTION
This should fix the recent failures with `centos:8`, for example: https://github.com/neuronsimulator/nrn-build-ci/runs/2760370902?check_suite_focus=true

I filed a bug report upstream: https://bugs.centos.org/view.php?id=18212, but a workaround is just to add an extra `update` command, as suggested on that bug report.