### PR TITLE
Update to build on Debian 10 and 11

### DIFF
--- a/.github/workflows/build-neuron.yml
+++ b/.github/workflows/build-neuron.yml
@@ -78,12 +78,13 @@ jobs:
         - { vm: ubuntu-latest, container: "ubuntu:18.04", flavour: debian }
         # Ubuntu Latest (20.04, at time of writing) Docker image
         - { vm: ubuntu-latest, container: "ubuntu:latest", flavour: debian }
-        # Debian stretch Docker image: disabled because there does not
-        # appear to be a supported way of getting a recent version of CMake
-        # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=954852
-        # - { vm: ubuntu-latest, container: "debian:stretch", flavour: debian }
-        # Debian stable (10/buster, at time of writing) Docker image
-        - { vm: ubuntu-latest, container: "debian:stable", flavour: debian }
+        # Debian Buster (10) Docker image
+        - { vm: ubuntu-latest, container: "debian:buster", flavour: debian }
+        # Debian Bullseye (11) Docker image
+        # TODO: this should be changed to `debian:stable` so we notice when
+        #       Debian 12 is released, but immediately after the Debian 11
+        #       release that is not working.
+        - { vm: ubuntu-latest, container: "debian:bullseye", flavour: debian }
         branch_or_tag: ${{ fromJson(needs.provide_version_matrix.outputs.matrix) }}
       fail-fast: false
       


### PR DESCRIPTION
Previously we just had Debian 10 via `debian:stable`, but it stopped working when Debian 11 was released.
This is now consistent with other distributions where we use the two newest releases.
Once the `debian:stable` image is working again we should change `debian:bullseye` to `debian:stable`.