### PR TITLE
Install newer CMake verisons for ubuntu:18.04 and debian:buster.

### DIFF
--- a/scripts/install_debian_debian:buster.sh
+++ b/scripts/install_debian_debian:buster.sh
@@ -1,0 +1,4 @@
+# Install a more recent version of CMake
+echo 'deb http://deb.debian.org/debian buster-backports main' >> /etc/apt/sources.list
+apt-get update
+apt-get install -t buster-backports -y cmake

--- a/scripts/install_debian_ubuntu:18.04.sh
+++ b/scripts/install_debian_ubuntu:18.04.sh
@@ -1,0 +1,9 @@
+# Enable Kitware repository to pick up a modern version of CMake
+# Instructions adapted from https://apt.kitware.com/
+apt-get update
+apt-get install -y gpg wget
+wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - > /usr/share/keyrings/kitware-archive-keyring.gpg
+echo 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ bionic main' > /etc/apt/sources.list.d/kitware.list
+apt-get update
+rm /usr/share/keyrings/kitware-archive-keyring.gpg
+apt-get install -y kitware-archive-keyring


### PR DESCRIPTION
At the time of writing, this provides 3.16.3 for `debian:buster` and 3.21.1 for `ubuntu:18.04`.