### PR TITLE
Update Fedora jobs.

### DIFF
--- a/.github/workflows/build-neuron.yml
+++ b/.github/workflows/build-neuron.yml
@@ -33,8 +33,8 @@ jobs:
         repository: neuronsimulator/nrn
     - id: provide_versions
       run: |
-        # Test the latest release on Tuesdays.
-        if [ $(date +%u) -eq 2 ]
+        # Test the latest release on Mondays.
+        if [ $(date +%u) -eq 1 ]
         then
           echo "::set-output name=matrix::[\"\", \"${{steps.get_latest_release.outputs.release }}\"]"
         else
@@ -81,7 +81,9 @@ jobs:
         # Debian Bullseye (11) Docker image
         - { vm: ubuntu-latest, container: "debian:stable", flavour: debian }
         branch_or_tag: ${{ fromJson(needs.provide_version_matrix.outputs.matrix) }}
-        # Avoid the fedora:latest + 8.0.0 combination.
+        # Avoid the fedora:latest + 8.0.0 combination, we should re-enable this
+        # later. See https://github.com/neuronsimulator/nrn-build-ci/issues/28
+        # for more information.
         include:
           # Fedora Latest (35, at time of writing) Docker image
           - os: { vm: ubuntu-latest, container: "fedora:latest", flavour: redhat }

--- a/.github/workflows/build-neuron.yml
+++ b/.github/workflows/build-neuron.yml
@@ -72,8 +72,6 @@ jobs:
         - { vm: ubuntu-latest, container: "centos:8", flavour: redhat }
         # Fedora 34 Docker image
         - { vm: ubuntu-latest, container: "fedora:34", flavour: redhat }
-        # Fedora Latest (35, at time of writing) Docker image
-        - { vm: ubuntu-latest, container: "fedora:latest", flavour: redhat }
         # Ubuntu 18.04 Docker image
         - { vm: ubuntu-latest, container: "ubuntu:18.04", flavour: debian }
         # Ubuntu Latest (20.04, at time of writing) Docker image
@@ -83,9 +81,11 @@ jobs:
         # Debian Bullseye (11) Docker image
         - { vm: ubuntu-latest, container: "debian:stable", flavour: debian }
         branch_or_tag: ${{ fromJson(needs.provide_version_matrix.outputs.matrix) }}
-        exclude:
-          - os.container: "fedora:latest"
-            branch_or_tag: "8.0.0"
+        # Avoid the fedora:latest + 8.0.0 combination.
+        include:
+          # Fedora Latest (35, at time of writing) Docker image
+          - os: { vm: ubuntu-latest, container: "fedora:latest", flavour: redhat }
+            branch_or_tag: ""
       fail-fast: false
       
     steps:

--- a/.github/workflows/build-neuron.yml
+++ b/.github/workflows/build-neuron.yml
@@ -33,8 +33,8 @@ jobs:
         repository: neuronsimulator/nrn
     - id: provide_versions
       run: |
-        # Test the latest release on Mondays.
-        if [ $(date +%u) -eq 1 ]
+        # Test the latest release on Tuesdays.
+        if [ $(date +%u) -eq 2 ]
         then
           echo "::set-output name=matrix::[\"\", \"${{steps.get_latest_release.outputs.release }}\"]"
         else
@@ -83,6 +83,9 @@ jobs:
         # Debian Bullseye (11) Docker image
         - { vm: ubuntu-latest, container: "debian:stable", flavour: debian }
         branch_or_tag: ${{ fromJson(needs.provide_version_matrix.outputs.matrix) }}
+        exclude:
+          - os.container: "fedora:latest"
+            branch_or_tag: "8.0.0"
       fail-fast: false
       
     steps:

--- a/.github/workflows/build-neuron.yml
+++ b/.github/workflows/build-neuron.yml
@@ -70,9 +70,9 @@ jobs:
         - { vm: ubuntu-latest, container: "centos:7", flavour: redhat }
         # CentOS8 Docker image
         - { vm: ubuntu-latest, container: "centos:8", flavour: redhat }
-        # Fedora 33 Docker image
-        - { vm: ubuntu-latest, container: "fedora:33", flavour: redhat }
-        # Fedora Latest (34, at time of writing) Docker image
+        # Fedora 34 Docker image
+        - { vm: ubuntu-latest, container: "fedora:34", flavour: redhat }
+        # Fedora Latest (35, at time of writing) Docker image
         - { vm: ubuntu-latest, container: "fedora:latest", flavour: redhat }
         # Ubuntu 18.04 Docker image
         - { vm: ubuntu-latest, container: "ubuntu:18.04", flavour: debian }


### PR DESCRIPTION
- Update second-newest Fedora from 33 to 34.
- Do not test the latest NEURON release against Fedora 35 (https://github.com/neuronsimulator/nrn-build-ci/issues/28).
- NEURON `master` is still broken on Fedora 35 (https://github.com/neuronsimulator/nrn/issues/1525).