### PR TITLE
NEURON 8.0.2 should be Fedora 35 compatible.

### DIFF
--- a/.github/workflows/build-neuron.yml
+++ b/.github/workflows/build-neuron.yml
@@ -36,7 +36,7 @@ jobs:
     - id: provide_versions
       run: |
         # Test the latest release on Mondays, and if we are not being told to test a specific branch
-        if [[ $(date +%u) == 1 && '${{github.event.inputs.neuron_branch}}' == "" ]]
+        if [[ $(date +%u) == 4 && '${{github.event.inputs.neuron_branch}}' == "" ]]
         then
           echo "::set-output name=matrix::[\"\", \"${{steps.get_latest_release.outputs.release }}\"]"
         else
@@ -73,6 +73,8 @@ jobs:
         - { vm: ubuntu-latest, container: "quay.io/centos/centos:stream9", flavour: redhat }
         # Fedora 34 Docker image
         - { vm: ubuntu-latest, container: "fedora:34", flavour: redhat }
+        # Fedora Latest (35, at time of writing) Docker image
+        - { vm: ubuntu-latest, container: "fedora:latest", flavour: redhat }
         # Ubuntu 18.04 Docker image
         - { vm: ubuntu-latest, container: "ubuntu:18.04", flavour: debian }
         # Ubuntu Latest (20.04, at time of writing) Docker image
@@ -82,13 +84,6 @@ jobs:
         # Debian Bullseye (11) Docker image
         - { vm: ubuntu-latest, container: "debian:stable", flavour: debian }
         branch_or_tag: ${{ fromJson(needs.provide_version_matrix.outputs.matrix) }}
-        # Avoid the fedora:latest + 8.0.0 combination, we should re-enable this
-        # later. See https://github.com/neuronsimulator/nrn-build-ci/issues/28
-        # for more information.
-        include:
-          # Fedora Latest (35, at time of writing) Docker image
-          - os: { vm: ubuntu-latest, container: "fedora:latest", flavour: redhat }
-            branch_or_tag: "${{github.event.inputs.neuron_branch}}"
       fail-fast: false
       
     steps:


### PR DESCRIPTION
Switch latest release testing to run on Thursday. Closes #28.