### PR TITLE
Test release wheels when testing tags.

### DIFF
--- a/.github/workflows/build-neuron.yml
+++ b/.github/workflows/build-neuron.yml
@@ -151,6 +151,8 @@ jobs:
       - name: Test nightly NEURON wheel
         working-directory: ${{github.workspace}}/nrn
         run: ../wrappers/runUnprivileged.sh ../scripts/testNeuronWheel.sh
+        env:
+          NEURON_BRANCH_OR_TAG: ${{matrix.branch_or_tag}}
 
       # This step will set up an SSH connection on tmate.io for live debugging
       # of non-Docker runs that failed.

--- a/scripts/testNeuronWheel.sh
+++ b/scripts/testNeuronWheel.sh
@@ -1,11 +1,12 @@
 #!/bin/bash
+set -x
 # Set up the runtime environment by sourcing the environmentXXX.sh scripts.
 # For a local installation you might have put the content of those scripts
 # directly into your ~/.bashrc or ~/.zshrc
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+source "${SCRIPT_DIR}/environment.sh"
 DROP_DIR="${SCRIPT_DIR}/../drop"
 USE_VENV="true"
-source "${SCRIPT_DIR}/environment.sh"
 # If Azure drop is there, install the wheel
 if [[ -d "${DROP_DIR}" ]]; then
   # upgrade pip for 3.6 (for manylinux2014 support)
@@ -17,8 +18,14 @@ if [[ -d "${DROP_DIR}" ]]; then
   # install wheel from drop
   python3 -m pip install --user --find-links ${DROP_DIR} neuron-nightly
   # get Azure version to avoid downloading something else in the venv for test_wheels.sh
-  NRN_NIGHTLY_VER="==$( python3 -m pip show neuron-nightly | grep Version | cut -d ' ' -f2 )"
+  NRN_PACKAGE="neuron-nightly==$( python3 -m pip show neuron-nightly | grep Version | cut -d ' ' -f2 )"
   USE_VENV="false"
+elif [[ -n "${NEURON_BRANCH_OR_TAG}" ]]; then
+  # Assume it's a tag that matches the PyPI release version
+  NRN_PACKAGE="neuron==${NEURON_BRANCH_OR_TAG}"
+else
+  NRN_PACKAGE="neuron-nightly"
 fi
 # Run NEURON's wheel testing script
-./packaging/python/test_wheels.sh python3 neuron-nightly${NRN_NIGHTLY_VER} $USE_VENV
+echo "Testing NEURON wheel: ${NRN_PACKAGE} (venv=${USE_VENV})"
+./packaging/python/test_wheels.sh python3 ${NRN_PACKAGE} ${USE_VENV}

--- a/wrappers/runUnprivileged.sh
+++ b/wrappers/runUnprivileged.sh
@@ -22,6 +22,7 @@ then
 fi
 echo "Wrapper script generated command prefix: ${CMD_PREFIX}"
 QUOTED_ARGS=$(printf " %q" "$@")
-${CMD_PREFIX} sh -c "INSTALL_DIR=${INSTALL_DIR} OS_FLAVOUR=${OS_FLAVOUR}\
+${CMD_PREFIX} sh -c "INSTALL_DIR=${INSTALL_DIR}\
+ NEURON_BRANCH_OR_TAG=${NEURON_BRANCH_OR_TAG} OS_FLAVOUR=${OS_FLAVOUR}\
  OS_CONTAINER=${OS_CONTAINER} bash --noprofile --norc -e -o pipefail\
  --${QUOTED_ARGS}"


### PR DESCRIPTION
The CI [failed this morning](https://github.com/neuronsimulator/nrn-build-ci/actions/runs/1960849855) and I realised that when we test the latest release (currently the 8.0.2 tag) of NEURON then we were still installing and testing `neuron-nightly` wheels.

With this change then the builds testing the `8.0.2` tag of NEURON install and test `neuron==8.0.2`.