### PR TITLE
Use Python 3.7+ everywhere.

### DIFF
--- a/.github/workflows/build-neuron.yml
+++ b/.github/workflows/build-neuron.yml
@@ -56,7 +56,7 @@ jobs:
       OS_FLAVOUR: ${{matrix.os.flavour}}
       UNPRIVILEGED_USER: runner # User created+used inside Docker containers
       # Extra software collections to be installed and enabled on CentOS7
-      SOFTWARE_COLLECTIONS_centos_7: devtoolset-9 rh-git218
+      SOFTWARE_COLLECTIONS_centos_7: devtoolset-9 rh-git218 rh-python38
 
     strategy:
       matrix:

--- a/scripts/buildNeuron.sh
+++ b/scripts/buildNeuron.sh
@@ -21,6 +21,9 @@ pip install --upgrade pip
 # Use the virtual environment python instead of the system one it redirects to
 export PYTHON=$(command -v python)
 
+# nrniv -python does not copy properly with virtualenvs
+export PYTHONPATH=$(${PYTHON} -c 'import site; print(":".join(site.getsitepackages()))')
+
 # Install extra dependencies for NEURON into the virtual environment.
 pip install --upgrade bokeh cython ipython matplotlib mpi4py numpy pytest \
   pytest-cov scikit-build
@@ -59,8 +62,7 @@ if [ "${OS_FLAVOUR}" == "macOS" ]; then
 else
   PARALLEL_JOBS=2
 fi
-# The --parallel option to CMake was only added in v3.12
-cmake --build . -- -j ${PARALLEL_JOBS}
+cmake --build . --parallel ${PARALLEL_JOBS}
 
 echo "------- Install NEURON -------"
 cmake --build . -- install

--- a/scripts/buildNeuron.sh
+++ b/scripts/buildNeuron.sh
@@ -5,15 +5,25 @@
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 source "${SCRIPT_DIR}/environment.sh"
 
-# Choose which Python version to use
-export PYTHON=$(command -v python3)
+# Choose which Python version to use. If an installation script set NRN_PYTHON,
+# use that.
+export PYTHON=${NRN_PYTHON:-$(command -v python3)}
 
-# Install extra dependencies for NEURON
+# Set up a virtual environment. On some distros (Ubuntu 18.04 + Python 3.7) we
+# only get venv from the system packages, not pip.
+${PYTHON} -m venv nrn_venv
+. nrn_venv/bin/activate
+
 # Make sure we have a modern pip, old ones may not handle dependency versions
 # correctly
-${PYTHON} -m pip install --user --upgrade pip
-${PYTHON} -m pip install --user --upgrade bokeh cython ipython matplotlib \
-  mpi4py pytest pytest-cov scikit-build
+pip install --upgrade pip
+
+# Use the virtual environment python instead of the system one it redirects to
+export PYTHON=$(command -v python)
+
+# Install extra dependencies for NEURON into the virtual environment.
+pip install --upgrade bokeh cython ipython matplotlib mpi4py numpy pytest \
+  pytest-cov scikit-build
 
 # Set default compilers, but don't override preset values
 export CC=${CC:-gcc}

--- a/scripts/environment.sh
+++ b/scripts/environment.sh
@@ -6,8 +6,3 @@ ENV_SCRIPT_CONTAINER="${SCRIPT_DIR}/environment_${OS_FLAVOUR}_${OS_CONTAINER}.sh
 if [ -f "${ENV_SCRIPT_CONTAINER}" ]; then source "${ENV_SCRIPT_CONTAINER}"; fi
 ENV_SCRIPT_FLAVOUR="${SCRIPT_DIR}/environment_${OS_FLAVOUR}.sh"
 if [ -f "${ENV_SCRIPT_FLAVOUR}" ]; then source "${ENV_SCRIPT_FLAVOUR}"; fi
-
-# Generic setup: make sure the user install directory used by pip is found
-PYTHON_USER_BASE=$(python3 -c "import site; print(site.USER_BASE)")
-export PATH=${PYTHON_USER_BASE}/bin:${PATH}
-export JUPYTER_PATH=${PYTHON_USER_BASE}/share/jupyter

--- a/scripts/install_debian.sh
+++ b/scripts/install_debian.sh
@@ -9,6 +9,10 @@ export DEBIAN_FRONTEND=noninteractive
 # ---
 apt-get update
 apt-get install -y bison cmake flex git libncurses-dev libmpich-dev \
-  libx11-dev libxcomposite-dev ninja-build mpich python3-numpy libreadline-dev \
-  python3-pip python3-setuptools python3-venv python3-wheel sudo wget unzip \
-  libssl-dev # for tqperf integration test
+  libx11-dev libxcomposite-dev ninja-build mpich libreadline-dev sudo wget \
+  unzip libssl-dev # for tqperf integration test
+if [[ -z "${NRN_PYTHON}" ]]; then
+  apt-get install -y python3-dev python3-venv
+  export NRN_PYTHON=$(command -v python3)
+  echo "NRN_PYTHON=${NRN_PYTHON}" >> $GITHUB_ENV
+fi

--- a/scripts/install_debian_ubuntu_18_04.sh
+++ b/scripts/install_debian_ubuntu_18_04.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # Enable Kitware repository to pick up a modern version of CMake
 # Instructions adapted from https://apt.kitware.com/
 apt-get update
@@ -7,3 +8,10 @@ echo 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://ap
 apt-get update
 rm /usr/share/keyrings/kitware-archive-keyring.gpg
 apt-get install -y kitware-archive-keyring
+# Enable https://launchpad.net/~deadsnakes/+archive/ubuntu/ppa to get
+# up-to-date packages for Python 3.7
+apt-get install -y software-properties-common # add-apt-repository
+add-apt-repository -y ppa:deadsnakes/ppa
+apt-get install -y python3.7-dev python3.7-venv
+export NRN_PYTHON=$(command -v python3.7)
+echo "NRN_PYTHON=${NRN_PYTHON}" >> $GITHUB_ENV

--- a/scripts/install_redhat.sh
+++ b/scripts/install_redhat.sh
@@ -2,7 +2,7 @@
 # Use DNF if available (not CentOS7), otherwise YUM
 CMD=$(command -v dnf || command -v yum)
 ${CMD} update -y
-${CMD} install -y bison cmake diffutils dnf flex gcc gcc-c++ git \
-  openmpi-devel libXcomposite-devel libXext-devel make readline-devel ncurses-devel \
-  ninja-build python3-devel python3-pip python3-wheel sudo which wget unzip \
-  findutils openssl-devel  # for tqperf integration test
+${CMD} install -y bison cmake diffutils dnf findutils flex gcc gcc-c++ git \
+  openmpi-devel libXcomposite-devel libXext-devel make python3-devel \
+  readline-devel ncurses-devel ninja-build sudo which wget unzip \
+  openssl-devel # for tqperf integration test

--- a/scripts/install_redhat_centos_7.sh
+++ b/scripts/install_redhat_centos_7.sh
@@ -4,7 +4,7 @@
 yum install -y epel-release centos-release-scl centos-release-scl-rh
 
 # Install a newer toolchain for CentOS7
-yum install -y cmake3 ${SOFTWARE_COLLECTIONS_centos_7}
+yum install -y cmake3 ${SOFTWARE_COLLECTIONS_centos_7} rh-python38-python-devel
 
 # Make sure `cmake` and `ctest` see the 3.x versions, instead of the ancient
 # CMake 2 included in CentOS7

--- a/scripts/install_redhat_centos_stream8.sh
+++ b/scripts/install_redhat_centos_stream8.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
 # Enable the (official) PowerTools repository. This provides Ninja.
-dnf install -y dnf-plugins-core
+dnf install -y dnf-plugins-core python38-devel
+export NRN_PYTHON=$(command -v python3.8)
+echo "NRN_PYTHON=${NRN_PYTHON}" >> $GITHUB_ENV
 dnf config-manager --set-enabled powertools

--- a/scripts/testNeuronWheel.sh
+++ b/scripts/testNeuronWheel.sh
@@ -7,18 +7,16 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 source "${SCRIPT_DIR}/environment.sh"
 DROP_DIR="${SCRIPT_DIR}/../drop"
 USE_VENV="true"
+export PYTHON=${NRN_PYTHON:-$(command -v python3)}
 # If Azure drop is there, install the wheel
 if [[ -d "${DROP_DIR}" ]]; then
-  # upgrade pip for 3.6 (for manylinux2014 support)
-  python_ver=$( python3 -c "import sys; print('%d%d' % tuple(sys.version_info)[:2])" )
-  if [[ "$python_ver" == "36" ]]; then
-    python3 -m pip install --user --upgrade pip
-  fi
-
+  ${PYTHON} -m venv wheel_test_venv
+  . wheel_test_venv/bin/activate
+  export PYTHON=$(command -v python)
   # install wheel from drop
-  python3 -m pip install --user --find-links ${DROP_DIR} neuron-nightly
+  pip install --find-links ${DROP_DIR} neuron-nightly
   # get Azure version to avoid downloading something else in the venv for test_wheels.sh
-  NRN_PACKAGE="neuron-nightly==$( python3 -m pip show neuron-nightly | grep Version | cut -d ' ' -f2 )"
+  NRN_PACKAGE="neuron-nightly==$(pip show neuron-nightly | grep Version | cut -d ' ' -f2 )"
   USE_VENV="false"
 elif [[ -n "${NEURON_BRANCH_OR_TAG}" ]]; then
   # Assume it's a tag that matches the PyPI release version
@@ -28,4 +26,4 @@ else
 fi
 # Run NEURON's wheel testing script
 echo "Testing NEURON wheel: ${NRN_PACKAGE} (venv=${USE_VENV})"
-./packaging/python/test_wheels.sh python3 ${NRN_PACKAGE} ${USE_VENV}
+./packaging/python/test_wheels.sh ${PYTHON} ${NRN_PACKAGE} ${USE_VENV}

--- a/wrappers/runUnprivileged.sh
+++ b/wrappers/runUnprivileged.sh
@@ -23,6 +23,6 @@ fi
 echo "Wrapper script generated command prefix: ${CMD_PREFIX}"
 QUOTED_ARGS=$(printf " %q" "$@")
 ${CMD_PREFIX} sh -c "INSTALL_DIR=${INSTALL_DIR}\
- NEURON_BRANCH_OR_TAG=${NEURON_BRANCH_OR_TAG} OS_FLAVOUR=${OS_FLAVOUR}\
- OS_CONTAINER=${OS_CONTAINER} bash --noprofile --norc -e -o pipefail\
- --${QUOTED_ARGS}"
+ NEURON_BRANCH_OR_TAG=${NEURON_BRANCH_OR_TAG} NRN_PYTHON=${NRN_PYTHON} \
+ OS_FLAVOUR=${OS_FLAVOUR} OS_CONTAINER=${OS_CONTAINER} \
+ bash --noprofile --norc -e -o pipefail --${QUOTED_ARGS}"


### PR DESCRIPTION
Support for Python 3.6 was dropped in neuronsimulator/nrn#1733. Now we:
- Install 3.8 on CentOS7 and CentOS Stream 8.
- Install 3.7 on Ubuntu 18.04.
- Drop a 3.6-specific workaround.

To get everything working, also:
- Install numpy using pip, not the package manager.
- Cleanup some old PATH/JUPYTER_PATH manipulation.
- Set up and use a virtual environment, as pythonX -m venv works on some
  distributions when pythonX -m pip does not.