### PR TITLE
Install Boost, Fedora 34 -> 35

### DIFF
--- a/.github/workflows/build-neuron.yml
+++ b/.github/workflows/build-neuron.yml
@@ -71,9 +71,9 @@ jobs:
         - { vm: ubuntu-latest, container: "quay.io/centos/centos:stream8", flavour: redhat }
         # CentOS Stream 9 Docker image
         - { vm: ubuntu-latest, container: "quay.io/centos/centos:stream9", flavour: redhat }
-        # Fedora 34 Docker image
-        - { vm: ubuntu-latest, container: "fedora:34", flavour: redhat }
-        # Fedora Latest (35, at time of writing) Docker image
+        # Fedora 35 Docker image
+        - { vm: ubuntu-latest, container: "fedora:35", flavour: redhat }
+        # Fedora Latest (36, at time of writing) Docker image
         - { vm: ubuntu-latest, container: "fedora:latest", flavour: redhat }
         # Ubuntu 20.04 Docker image
         - { vm: ubuntu-latest, container: "ubuntu:20.04", flavour: debian }

--- a/scripts/install_debian.sh
+++ b/scripts/install_debian.sh
@@ -8,9 +8,9 @@ export DEBIAN_FRONTEND=noninteractive
 # --- End GitHub-Actions-specific code ---
 # ---
 apt-get update
-apt-get install -y bison cmake flex git libncurses-dev libmpich-dev \
-  libx11-dev libxcomposite-dev ninja-build mpich libreadline-dev sudo wget \
-  unzip libssl-dev # for tqperf integration test
+apt-get install -y bison cmake flex git libboost-dev libncurses-dev \
+  libmpich-dev libssl-dev libx11-dev libxcomposite-dev ninja-build \
+  mpich libreadline-dev sudo wget unzip
 if [[ -z "${NRN_PYTHON}" ]]; then
   apt-get install -y python3-dev python3-venv
   export NRN_PYTHON=$(command -v python3)

--- a/scripts/install_debian.sh
+++ b/scripts/install_debian.sh
@@ -8,9 +8,9 @@ export DEBIAN_FRONTEND=noninteractive
 # --- End GitHub-Actions-specific code ---
 # ---
 apt-get update
-apt-get install -y bison cmake flex git libboost-dev libncurses-dev \
-  libmpich-dev libssl-dev libx11-dev libxcomposite-dev ninja-build \
-  mpich libreadline-dev sudo wget unzip
+apt-get install -y bison cmake flex git libboost-all-dev \
+  libncurses-dev libmpich-dev libssl-dev libx11-dev \
+  libxcomposite-dev ninja-build mpich libreadline-dev sudo wget unzip
 if [[ -z "${NRN_PYTHON}" ]]; then
   apt-get install -y python3-dev python3-venv
   export NRN_PYTHON=$(command -v python3)

--- a/scripts/install_macOS.sh
+++ b/scripts/install_macOS.sh
@@ -1,4 +1,4 @@
-brew install coreutils flex mpich ninja xz wget
+brew install boost coreutils flex mpich ninja xz wget
 brew unlink mpich
 brew install openmpi
 brew install --cask xquartz

--- a/scripts/install_redhat.sh
+++ b/scripts/install_redhat.sh
@@ -2,7 +2,7 @@
 # Use DNF if available (not CentOS7), otherwise YUM
 CMD=$(command -v dnf || command -v yum)
 ${CMD} update -y
-${CMD} install -y bison cmake diffutils dnf findutils flex gcc gcc-c++ git \
-  openmpi-devel libXcomposite-devel libXext-devel make python3-devel \
-  readline-devel ncurses-devel ninja-build sudo which wget unzip \
-  openssl-devel # for tqperf integration test
+${CMD} install -y bison boost-devel cmake diffutils dnf findutils \
+  flex gcc gcc-c++ git openmpi-devel libXcomposite-devel \
+  libXext-devel make openssl-devel python3-devel readline-devel \
+  ncurses-devel ninja-build sudo which wget unzip


### PR DESCRIPTION
This is an optional dependency in CoreNEURON.
Without it, some unit tests are not run.
Also, Fedora 36 is out so our 2nd-newest version should be 35.