### PR TITLE
Use MPICH on centos 7 and use GCC v9 everywhere

### DIFF
--- a/.github/workflows/build-neuron.yml
+++ b/.github/workflows/build-neuron.yml
@@ -126,8 +126,7 @@ jobs:
         working-directory: ${{github.workspace}}
         run: |
           if [ -n "${{matrix.branch_or_tag}}" ]; then BRANCH_OPT="--branch=${{matrix.branch_or_tag}}"; fi
-          #git clone --depth=1 --single-branch ${BRANCH_OPT} ${{github.server_url}}/${{github.repository_owner}}/nrn
-          git clone --depth=1 --single-branch --branch=pramodk/centos7-mpich ${{github.server_url}}/${{github.repository_owner}}/nrn
+          git clone --depth=1 --single-branch ${BRANCH_OPT} ${{github.server_url}}/${{github.repository_owner}}/nrn
           # Init submodules for testing purposes
           cd nrn && git submodule update --init
 
@@ -144,12 +143,12 @@ jobs:
           chown -R ${UNPRIVILEGED_USER}:${UNPRIVILEGED_USER} ${GITHUB_WORKSPACE}
     
       # Put all the remaining steps in one job that runs as an unprivileged user
-      #- name: Build and test NEURON
-      #  if: ${{!github.event.inputs.azure_drop_url}}
-      #  working-directory: ${{github.workspace}}/nrn
-      #  run: ../wrappers/runUnprivileged.sh ../scripts/buildNeuron.sh
-      #  env:
-      #    INSTALL_DIR : ${{github.workspace}}/nrn/install
+      - name: Build and test NEURON
+        if: ${{!github.event.inputs.azure_drop_url}}
+        working-directory: ${{github.workspace}}/nrn
+        run: ../wrappers/runUnprivileged.sh ../scripts/buildNeuron.sh
+        env:
+          INSTALL_DIR : ${{github.workspace}}/nrn/install
 
       # Download specific wheels from Azure via workflow dispatch
       - name: Download Azure drop (artifacts) -> ${{ github.event.inputs.azure_drop_url }}

--- a/.github/workflows/build-neuron.yml
+++ b/.github/workflows/build-neuron.yml
@@ -144,12 +144,12 @@ jobs:
           chown -R ${UNPRIVILEGED_USER}:${UNPRIVILEGED_USER} ${GITHUB_WORKSPACE}
     
       # Put all the remaining steps in one job that runs as an unprivileged user
-      - name: Build and test NEURON
-        if: ${{!github.event.inputs.azure_drop_url}}
-        working-directory: ${{github.workspace}}/nrn
-        run: ../wrappers/runUnprivileged.sh ../scripts/buildNeuron.sh
-        env:
-          INSTALL_DIR : ${{github.workspace}}/nrn/install
+      #- name: Build and test NEURON
+      #  if: ${{!github.event.inputs.azure_drop_url}}
+      #  working-directory: ${{github.workspace}}/nrn
+      #  run: ../wrappers/runUnprivileged.sh ../scripts/buildNeuron.sh
+      #  env:
+      #    INSTALL_DIR : ${{github.workspace}}/nrn/install
 
       # Download specific wheels from Azure via workflow dispatch
       - name: Download Azure drop (artifacts) -> ${{ github.event.inputs.azure_drop_url }}

--- a/.github/workflows/build-neuron.yml
+++ b/.github/workflows/build-neuron.yml
@@ -126,7 +126,8 @@ jobs:
         working-directory: ${{github.workspace}}
         run: |
           if [ -n "${{matrix.branch_or_tag}}" ]; then BRANCH_OPT="--branch=${{matrix.branch_or_tag}}"; fi
-          git clone --depth=1 --single-branch ${BRANCH_OPT} ${{github.server_url}}/${{github.repository_owner}}/nrn
+          #git clone --depth=1 --single-branch ${BRANCH_OPT} ${{github.server_url}}/${{github.repository_owner}}/nrn
+          git clone --depth=1 --single-branch --branch=pramodk/centos7-mpich ${{github.server_url}}/${{github.repository_owner}}/nrn
           # Init submodules for testing purposes
           cd nrn && git submodule update --init
 

--- a/scripts/environment_redhat_centos_stream8.sh
+++ b/scripts/environment_redhat_centos_stream8.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+# Ensure that gcc-9 toolchain is enabled
+source /opt/rh/gcc-toolset-9/enable

--- a/scripts/install_redhat.sh
+++ b/scripts/install_redhat.sh
@@ -1,8 +1,18 @@
 #!/bin/bash
 # Use DNF if available (not CentOS7), otherwise YUM
 CMD=$(command -v dnf || command -v yum)
+
+# Use mpich on centos7 otherwise use openmpi
+# See neuronsimulator/nrn-build-ci/pull/51
+if cat /etc/*release | grep -q CentOS-7;
+then
+    mpi_lib=mpich-devel
+else
+    mpi_lib=openmpi-devel
+fi
+
 ${CMD} update -y
 ${CMD} install -y bison boost-devel cmake diffutils dnf findutils \
-  flex gcc gcc-c++ git openmpi-devel libXcomposite-devel \
+  flex gcc gcc-c++ git ${mpi_lib} libXcomposite-devel \
   libXext-devel make openssl-devel python3-devel readline-devel \
   ncurses-devel ninja-build sudo which wget unzip

--- a/scripts/install_redhat.sh
+++ b/scripts/install_redhat.sh
@@ -8,6 +8,6 @@ mpi_lib=$(if cat /etc/*release | grep -q CentOS-7; then echo "mpich-devel"; else
 
 ${CMD} update -y
 ${CMD} install -y bison boost-devel cmake diffutils dnf findutils \
-  flex gcc gcc-c++ git ${mpi_lib} libXcomposite-devel \
+  flex gcc gcc-c++ git ${mpi_lib:-openmpi-devel} libXcomposite-devel \
   libXext-devel make openssl-devel python3-devel readline-devel \
   ncurses-devel ninja-build sudo which wget unzip

--- a/scripts/install_redhat.sh
+++ b/scripts/install_redhat.sh
@@ -2,10 +2,6 @@
 # Use DNF if available (not CentOS7), otherwise YUM
 CMD=$(command -v dnf || command -v yum)
 
-# Use mpich on centos7 otherwise use openmpi
-# See neuronsimulator/nrn-build-ci/pull/51
-mpi_lib=$(if cat /etc/*release | grep -q CentOS-7; then echo "mpich-devel"; else echo "openmpi-devel"; fi)
-
 ${CMD} update -y
 ${CMD} install -y bison boost-devel cmake diffutils dnf findutils \
   flex gcc gcc-c++ git ${mpi_lib:-openmpi-devel} libXcomposite-devel \

--- a/scripts/install_redhat.sh
+++ b/scripts/install_redhat.sh
@@ -4,12 +4,7 @@ CMD=$(command -v dnf || command -v yum)
 
 # Use mpich on centos7 otherwise use openmpi
 # See neuronsimulator/nrn-build-ci/pull/51
-if cat /etc/*release | grep -q CentOS-7;
-then
-    mpi_lib=mpich-devel
-else
-    mpi_lib=openmpi-devel
-fi
+mpi_lib=$(if cat /etc/*release | grep -q CentOS-7; then echo "mpich-devel"; else echo "openmpi-devel"; fi)
 
 ${CMD} update -y
 ${CMD} install -y bison boost-devel cmake diffutils dnf findutils \

--- a/scripts/install_redhat_centos_7.sh
+++ b/scripts/install_redhat_centos_7.sh
@@ -6,6 +6,9 @@ yum install -y epel-release centos-release-scl centos-release-scl-rh
 # Install a newer toolchain for CentOS7
 yum install -y cmake3 ${SOFTWARE_COLLECTIONS_centos_7} rh-python38-python-devel
 
+# Remove older openmpi and install v3 instead
+yum remove -y openmpi-devel && yum install -y openmpi3-devel
+
 # Make sure `cmake` and `ctest` see the 3.x versions, instead of the ancient
 # CMake 2 included in CentOS7
 alternatives --install /usr/local/bin/cmake cmake /usr/bin/cmake3 20 \

--- a/scripts/install_redhat_centos_7.sh
+++ b/scripts/install_redhat_centos_7.sh
@@ -1,13 +1,11 @@
 #!/bin/bash
+
 # EPEL is needed to get CMake 3 in CentOS7
 # SCL is needed to get a modern toolchain in CentOS7
 yum install -y epel-release centos-release-scl centos-release-scl-rh
 
 # Install a newer toolchain for CentOS7
 yum install -y cmake3 ${SOFTWARE_COLLECTIONS_centos_7} rh-python38-python-devel
-
-# Remove older openmpi and install v3 instead
-yum remove -y openmpi-devel && yum install -y openmpi3-devel
 
 # Make sure `cmake` and `ctest` see the 3.x versions, instead of the ancient
 # CMake 2 included in CentOS7

--- a/scripts/install_redhat_centos_7.sh
+++ b/scripts/install_redhat_centos_7.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
-
+# Use MPICH instead of OpenMPI on CentOS7, see #51.
+# This variable will be read by install_redhat.sh
+mpi_lib=mpich-devel
 # EPEL is needed to get CMake 3 in CentOS7
 # SCL is needed to get a modern toolchain in CentOS7
 yum install -y epel-release centos-release-scl centos-release-scl-rh

--- a/scripts/install_redhat_centos_stream8.sh
+++ b/scripts/install_redhat_centos_stream8.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Enable the (official) PowerTools repository. This provides Ninja.
-dnf install -y dnf-plugins-core python38-devel
+dnf install -y dnf-plugins-core python38-devel gcc-toolset-9-gcc gcc-toolset-9-gcc-c++
 export NRN_PYTHON=$(command -v python3.8)
 echo "NRN_PYTHON=${NRN_PYTHON}" >> $GITHUB_ENV
 dnf config-manager --set-enabled powertools


### PR DESCRIPTION
 * centos 7 has openmpi 1.10 version via `openmpi-devel` package
 * when python is used to launch neuron, older openmpi versions
   seem to have problem. See relevant discussion in
     https://ngsolve.org/forum/ngspy-forum/771-open-mpi-question
 * using newer openmpi (>=3) via `openmpi3-devel` package seems to
   work fine

fixes neuronsimulator/nrn/issues/1968