### PR TITLE
Avoid deprecations, improve wheel logic.

### DIFF
--- a/.github/workflows/build-neuron.yml
+++ b/.github/workflows/build-neuron.yml
@@ -27,20 +27,33 @@ jobs:
       if: github.event_name == 'workflow_dispatch' && github.event.inputs.azure_drop_url
       run: |
         curl -sfSI -X GET '${{ github.event.inputs.azure_drop_url }}'
-
-    - id: get_latest_release
-      uses: pozetroninc/github-action-get-latest-release@v0.5.0
+    - name: Get latest release information
+      id: get_latest_release
+      uses: joutvhu/get-release@v1
+      env:
+        GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
       with:
-        excludes: prerelease, draft
-        repository: neuronsimulator/nrn
-    - id: provide_versions
+        debug: true
+        latest: true
+        prerelease: true
+        repo: "nrn"
+    - name: Construct matrix of branch/tag names and wheel versions to test
+      id: provide_versions
       run: |
-        # Test the latest release on Mondays, and if we are not being told to test a specific branch
-        if [[ $(date +%u) == 1 && '${{github.event.inputs.neuron_branch}}' == "" ]]
+        if [[ '${{github.event.inputs.neuron_branch}}' == "" ]]
         then
-          echo "::set-output name=matrix::[\"\", \"${{steps.get_latest_release.outputs.release }}\"]"
+          # If we're not told to test a specific branch, test the default branch with neuron-nightly wheels
+          values="{\"branch_or_tag\": \"\", \"default_wheel\": \"neuron-nightly\"}"
+          if [[ $(date +%u) == 1 ]]
+          then
+            # If it's a Monday, test the latest release (and latest released wheels) in addition
+            tag_name="${{steps.get_latest_release.outputs.tag_name}}"
+            values="${values}, {\"branch_or_tag\": \"${tag_name}\", \"default_wheel\": \"neuron==${tag_name}\"}"
+          fi
+          echo "matrix=[${values}]" >> $GITHUB_OUTPUT
         else
-          echo "::set-output name=matrix::[\"${{github.event.inputs.neuron_branch}}\"]"
+          # Test the given branch with no wheels by default. If an Azure URL is given, those wheels will be used.
+          echo "matrix=[{\"branch_or_tag\": \"${{github.event.inputs.neuron_branch}}\", \"default_wheel\": \"\"}]" >> $GITHUB_OUTPUT
         fi
     outputs:
       matrix: ${{ steps.provide_versions.outputs.matrix }}
@@ -50,7 +63,7 @@ jobs:
     needs: provide_version_matrix
     runs-on: ${{ matrix.os.vm }}
     container: ${{ matrix.os.container }}
-    name: ${{matrix.os.container || matrix.os.vm}} ${{matrix.branch_or_tag}}
+    name: ${{matrix.os.container || matrix.os.vm}} ${{matrix.branch_or_tag_and_default_wheel.branch_or_tag}} ${{matrix.branch_or_tag_and_default_wheel.default_wheel}}
     env:
       SDK_ROOT: $(xcrun --sdk macosx --show-sdk-path)
       OS_FLAVOUR: ${{matrix.os.flavour}}
@@ -83,24 +96,28 @@ jobs:
         - { vm: ubuntu-latest, container: "debian:buster", flavour: debian }
         # Debian Bullseye (11) Docker image
         - { vm: ubuntu-latest, container: "debian:stable", flavour: debian }
-        branch_or_tag: ${{ fromJson(needs.provide_version_matrix.outputs.matrix) }}
+        branch_or_tag_and_default_wheel: ${{ fromJson(needs.provide_version_matrix.outputs.matrix) }}
         exclude:
           # Don't test the default branch (master) against Debian Buster as it
           # isn't straightforward to install GCC9+ there. Note that this will
           # still run when the CI is launched against a specific NEURON branch,
           # so some failures are still to be expected.
           - os: { vm: ubuntu-latest, container: "debian:buster", flavour: debian }
-            branch_or_tag: ""
+            branch_or_tag_and_default_wheel:
+              branch_or_tag: ""
+              default_wheel: neuron-nightly
           # Don't test the 8.2.1 release against CentOS7 because it will fail.
           # This is expected to be fixed in 8.2.2 (if that ever comes) by
           # https://github.com/BlueBrain/CoreNeuron/pull/862.
           - os: { vm: ubuntu-latest, container: "centos:7", flavour: redhat }
-            branch_or_tag: "8.2.1"
+            branch_or_tag_and_default_wheel:
+              branch_or_tag: "8.2.1"
+              default_wheel: "neuron==8.2.1"
       fail-fast: false
       
     steps:
       # Checkout the dedicated repository that steers the CI build
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3
 
       # Install required packages using the system package manager. This
       # includes installing or updating the git client to a sufficiently
@@ -130,7 +147,9 @@ jobs:
       - name: Checkout NEURON
         working-directory: ${{github.workspace}}
         run: |
-          if [ -n "${{matrix.branch_or_tag}}" ]; then BRANCH_OPT="--branch=${{matrix.branch_or_tag}}"; fi
+          branch_or_tag="${{matrix.branch_or_tag_and_default_wheel.branch_or_tag}}"
+          echo "branch_or_tag=${branch_or_tag}"
+          if [ -n "${branch_or_tag}" ]; then BRANCH_OPT="--branch=${branch_or_tag}"; fi
           git clone --depth=1 --single-branch ${BRANCH_OPT} ${{github.server_url}}/${{github.repository_owner}}/nrn
           # Init submodules for testing purposes
           cd nrn && git submodule update --init
@@ -149,7 +168,6 @@ jobs:
     
       # Put all the remaining steps in one job that runs as an unprivileged user
       - name: Build and test NEURON
-        if: ${{!github.event.inputs.azure_drop_url}}
         working-directory: ${{github.workspace}}/nrn
         run: ../wrappers/runUnprivileged.sh ../scripts/buildNeuron.sh
         env:
@@ -161,11 +179,16 @@ jobs:
         working-directory: ${{github.workspace}}
         run: ./scripts/getAzureDrop.sh '${{ github.event.inputs.azure_drop_url }}'
 
-      # Also check that the released wheels work on this platform
-      - name: Test nightly NEURON wheel
+      # Test the wheels. If an Azure URL was given, those wheels are used. Otherwise:
+      # - default branch (master): neuron-nightly
+      # - latest release (tag X.Y): neuron==X.Y
+      # - feature branch: wheels only tested if a URL is given
+      - name: Test (nightly) NEURON wheel
+        if: github.event.inputs.azure_drop_url || matrix.branch_or_tag_and_default_wheel.default_wheel
         working-directory: ${{github.workspace}}/nrn
         run: ../wrappers/runUnprivileged.sh ../scripts/testNeuronWheel.sh
         env:
+          NRN_PACKAGE: ${{matrix.branch_or_tag_and_default_wheel.default_wheel}}
           NEURON_BRANCH_OR_TAG: ${{matrix.branch_or_tag}}
 
       # This step will set up an SSH connection on tmate.io for live debugging

--- a/scripts/testNeuronWheel.sh
+++ b/scripts/testNeuronWheel.sh
@@ -18,11 +18,6 @@ if [[ -d "${DROP_DIR}" ]]; then
   # get Azure version to avoid downloading something else in the venv for test_wheels.sh
   NRN_PACKAGE="neuron-nightly==$(pip show neuron-nightly | grep Version | cut -d ' ' -f2 )"
   USE_VENV="false"
-elif [[ -n "${NEURON_BRANCH_OR_TAG}" ]]; then
-  # Assume it's a tag that matches the PyPI release version
-  NRN_PACKAGE="neuron==${NEURON_BRANCH_OR_TAG}"
-else
-  NRN_PACKAGE="neuron-nightly"
 fi
 # Run NEURON's wheel testing script
 echo "Testing NEURON wheel: ${NRN_PACKAGE} (venv=${USE_VENV})"

--- a/wrappers/runUnprivileged.sh
+++ b/wrappers/runUnprivileged.sh
@@ -25,4 +25,5 @@ QUOTED_ARGS=$(printf " %q" "$@")
 ${CMD_PREFIX} sh -c "INSTALL_DIR=${INSTALL_DIR}\
  NEURON_BRANCH_OR_TAG=${NEURON_BRANCH_OR_TAG} NRN_PYTHON=${NRN_PYTHON} \
  OS_FLAVOUR=${OS_FLAVOUR} OS_CONTAINER=${OS_CONTAINER} \
- bash --noprofile --norc -e -o pipefail --${QUOTED_ARGS}"
+ NRN_PACKAGE=${NRN_PACKAGE} bash --noprofile --norc -e -o pipefail \
+ --${QUOTED_ARGS}"


### PR DESCRIPTION
- Avoid an old GitHub Action that used a deprecated NodeJS version.
- Improve logic for which wheels are tested: now the default branch of NEURON is tested with neuron-nightly, the latest release of NEURON is tested with the corresponding released wheel, and features branches of NEURON default to not testing wheels. All of the above are overriden if an Azure drop URL is given: in that case, the wheels from the drop are used.