### PR TITLE
Bump Fedora versions, skip Fedora 37 + NEURON 8.2.1, skip macOS + NEURON 8.2.1

### DIFF
--- a/.github/workflows/build-neuron.yml
+++ b/.github/workflows/build-neuron.yml
@@ -84,9 +84,9 @@ jobs:
         - { vm: ubuntu-latest, container: "quay.io/centos/centos:stream8", flavour: redhat }
         # CentOS Stream 9 Docker image
         - { vm: ubuntu-latest, container: "quay.io/centos/centos:stream9", flavour: redhat }
-        # Fedora 35 Docker image
-        - { vm: ubuntu-latest, container: "fedora:35", flavour: redhat }
-        # Fedora Latest (36, at time of writing) Docker image
+        # Fedora 36 Docker image
+        - { vm: ubuntu-latest, container: "fedora:36", flavour: redhat }
+        # Fedora Latest (37, at time of writing) Docker image
         - { vm: ubuntu-latest, container: "fedora:latest", flavour: redhat }
         # Ubuntu 20.04 Docker image
         - { vm: ubuntu-latest, container: "ubuntu:20.04", flavour: debian }
@@ -110,6 +110,13 @@ jobs:
           # This is expected to be fixed in 8.2.2 (if that ever comes) by
           # https://github.com/BlueBrain/CoreNeuron/pull/862.
           - os: { vm: ubuntu-latest, container: "centos:7", flavour: redhat }
+            branch_or_tag_and_default_wheel:
+              branch_or_tag: "8.2.1"
+              default_wheel: "neuron==8.2.1"
+          # Don't test the 8.2.1 release against Fedora 37/latest because there
+          # are not any wheels for Python 3.11. This should be fixed in 8.2.2,
+          # see https://github.com/neuronsimulator/nrn/issues/2089.
+          - os: { vm: ubuntu-latest, container: "fedora:latest", flavour: redhat }
             branch_or_tag_and_default_wheel:
               branch_or_tag: "8.2.1"
               default_wheel: "neuron==8.2.1"

--- a/.github/workflows/build-neuron.yml
+++ b/.github/workflows/build-neuron.yml
@@ -120,6 +120,19 @@ jobs:
             branch_or_tag_and_default_wheel:
               branch_or_tag: "8.2.1"
               default_wheel: "neuron==8.2.1"
+          # Don't test the 8.2.1 release against macOS because it does not
+          # include fixes needed for new setuptools(?), see some combination of
+          # https://github.com/neuronsimulator/nrn/issues/1605
+          # https://github.com/neuronsimulator/nrn/pull/2073
+          # https://github.com/neuronsimulator/nrn/pull/2074
+          - os: { vm: macos-11, flavour: macOS }
+            branch_or_tag_and_default_wheel:
+              branch_or_tag: "8.2.1"
+              default_wheel: "neuron==8.2.1"
+          - os: { vm: macos-12, flavour: macOS }
+            branch_or_tag_and_default_wheel:
+              branch_or_tag: "8.2.1"
+              default_wheel: "neuron==8.2.1"
       fail-fast: false
       
     steps:


### PR DESCRIPTION
- Test Fedora 36 and 37 instead of 35 and 36
- Don't test NEURON 8.2.1 against Fedora 37, as this ships with Python 3.11 and there are no wheels for that combination.
- Disable failing macOS builds; these also need fixes in `release/8.2` that will be included in 8.2.2