### PR TITLE
Debian {10,11} -> {11,12}; update docs

### DIFF
--- a/.github/workflows/build-neuron.yml
+++ b/.github/workflows/build-neuron.yml
@@ -92,20 +92,11 @@ jobs:
         - { vm: ubuntu-latest, container: "ubuntu:20.04", flavour: debian }
         # Ubuntu Latest (22.04, at time of writing) Docker image
         - { vm: ubuntu-latest, container: "ubuntu:latest", flavour: debian }
-        # Debian Buster (10) Docker image
-        - { vm: ubuntu-latest, container: "debian:buster", flavour: debian }
         # Debian Bullseye (11) Docker image
+        - { vm: ubuntu-latest, container: "debian:bullseye", flavour: debian }
+        # At the time of writing, Debian Bookworm (12) Docker image
         - { vm: ubuntu-latest, container: "debian:stable", flavour: debian }
         branch_or_tag_and_default_wheel: ${{ fromJson(needs.provide_version_matrix.outputs.matrix) }}
-        exclude:
-          # Don't test the default branch (master) against Debian Buster as it
-          # isn't straightforward to install GCC9+ there. Note that this will
-          # still run when the CI is launched against a specific NEURON branch,
-          # so some failures are still to be expected.
-          - os: { vm: ubuntu-latest, container: "debian:buster", flavour: debian }
-            branch_or_tag_and_default_wheel:
-              branch_or_tag: ""
-              default_wheel: neuron-nightly
       fail-fast: false
       
     steps:

--- a/README.md
+++ b/README.md
@@ -9,6 +9,20 @@ At present Ubuntu 20.04, Ubuntu 22.04, Fedora 37, Fedora 38, CentOS7, CentOS
 Stream 8, CentOS Stream 9, Debian Bullseye (11), Debian Bookworm (12), macOS 11
 and macOS 12 are tested.
 
+The tested distributions are generally configured with the explicit
+name/version of the second-newest version of the distribution at the time,
+while a generic "latest" tag is used for the latest version (where available).
+
+This means that when a new version of a distribution is released, we
+automatically start testing it.
+When this happens, the old second-newest version generally becomes the
+third-newest version, and must be manually updated via pull request.
+This is often an opportunity to drop some version-specific scripts.
+The `fedora:latest` build is particulally useful, as Fedora has a relatively
+fast release cadence and often includes cutting-edge compilers and library
+versions; this means we can often spot issues via this build before they
+trickle down to other CI configurations and users in the community.
+
 The configuration of these builds serves as an up-to-date reference of how to build NEURON on each platform.
 
 ## System package installation

--- a/README.md
+++ b/README.md
@@ -2,8 +2,12 @@
 [![NEURON Build CI](https://github.com/neuronsimulator/nrn-build-ci/actions/workflows/build-neuron.yml/badge.svg)](https://github.com/neuronsimulator/nrn-build-ci/actions/workflows/build-neuron.yml)
 
 This repository hosts [scheduled GitHub Actions workflows](.github/workflows/neuron-ci.yaml) that verify that [the main NEURON repository](https://github.com/neuronsimulator/nrn) can be built and run on a variety of common Linux distributions and macOS versions.
-The default branch of NEURON is tested every night, and the latest tagged release is tested once a week.
-At present Ubuntu 18.04, Ubuntu 20.04, Fedora 34, Fedora 35, CentOS7, CentOS8, Debian Buster (10), Debian Bullseye (11), macOS 10.15 and macOS 11.0 are tested.
+The default branch of NEURON (and `neuron-nightly` wheel) is tested every night,
+and the latest tagged release (and corresponding `neuron` wheel) is tested once
+a week.
+At present Ubuntu 20.04, Ubuntu 22.04, Fedora 37, Fedora 38, CentOS7, CentOS
+Stream 8, CentOS Stream 9, Debian Bullseye (11), Debian Bookworm (12), macOS 11
+and macOS 12 are tested.
 
 The configuration of these builds serves as an up-to-date reference of how to build NEURON on each platform.
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ The tested distributions are generally configured with the explicit
 name/version of the second-newest version of the distribution at the time,
 while a generic "latest" tag is used for the latest version (where available).
 
+There is currently an exception for the CentOS family, where three versions are
+retained because the third-newest, CentOS7, is still in use on the BlueBrain5
+system.
+
 This means that when a new version of a distribution is released, we
 automatically start testing it.
 When this happens, the old second-newest version generally becomes the

--- a/scripts/buildNeuron.sh
+++ b/scripts/buildNeuron.sh
@@ -25,7 +25,7 @@ export PYTHON=$(command -v python)
 export PYTHONPATH=$(${PYTHON} -c 'import site; print(":".join(site.getsitepackages()))')
 
 # Install extra dependencies for NEURON into the virtual environment.
-pip install --upgrade bokeh cython ipython matplotlib mpi4py numpy pytest \
+pip install --upgrade bokeh "cython<3" ipython matplotlib mpi4py numpy pytest \
   pytest-cov scikit-build sympy
 
 # Set default compilers, but don't override preset values

--- a/scripts/environment_redhat_centos_stream9.sh
+++ b/scripts/environment_redhat_centos_stream9.sh
@@ -1,6 +1,3 @@
-#!/bin/bash
-# Ensure that gcc-9 toolchain is enabled
-source /opt/rh/gcc-toolset-9/enable
 # Inspired by https://github.com/open-mpi/ompi/issues/11295 to try and
 # avoid hangs when running MPI tests.
 export FI_PROVIDER="tcp"

--- a/scripts/install_debian_debian_buster.sh
+++ b/scripts/install_debian_debian_buster.sh
@@ -1,5 +1,0 @@
-# Install a more recent version of CMake
-echo 'deb http://deb.debian.org/debian buster-backports main' >> /etc/apt/sources.list
-apt-get update
-apt-get install -t buster-backports -y cmake
-DO_NOT_INSTALL_BOOST=true


### PR DESCRIPTION
> The current "stable" distribution of Debian is version 12, codenamed bookworm. It was released on June 10th, 2023. 

- OpenMPI workaround copied from https://github.com/neuronsimulator/nrn-build-ci/pull/59