### PR TITLE
Various CI fixes

### DIFF
--- a/.github/workflows/build-neuron.yml
+++ b/.github/workflows/build-neuron.yml
@@ -74,10 +74,10 @@ jobs:
     strategy:
       matrix:
         os:
+        # GitHub Actions MacOS 13 runner
+        - { vm: macos-13, flavour: macOS }
         # GitHub Actions MacOS 12 runner
         - { vm: macos-12, flavour: macOS }
-        # GitHub Actions MacOS 11 runner
-        - { vm: macos-11, flavour: macOS }
         # CentOS7 Docker image
         - { vm: ubuntu-latest, container: "centos:7", flavour: redhat }
         # CentOS Stream 8 Docker image

--- a/.github/workflows/build-neuron.yml
+++ b/.github/workflows/build-neuron.yml
@@ -44,9 +44,10 @@ jobs:
         then
           # If we're not told to test a specific branch, test the default branch with neuron-nightly wheels
           values="{\"branch_or_tag\": \"\", \"default_wheel\": \"neuron-nightly\"}"
-          if [[ $(date +%u) == 1 ]]
+          if [[ $(date +%u) == 1 ]] || [[ ${{ github.event_name }} == 'pull_request' ]]
           then
             # If it's a Monday, test the latest release (and latest released wheels) in addition
+            # Also test it on any PR
             tag_name="${{steps.get_latest_release.outputs.tag_name}}"
             values="${values}, {\"branch_or_tag\": \"${tag_name}\", \"default_wheel\": \"neuron==${tag_name}\"}"
           fi

--- a/.github/workflows/build-neuron.yml
+++ b/.github/workflows/build-neuron.yml
@@ -136,7 +136,7 @@ jobs:
           if [ -n "${branch_or_tag}" ]; then BRANCH_OPT="--branch=${branch_or_tag}"; fi
           git clone --depth=1 --single-branch ${BRANCH_OPT} ${{github.server_url}}/${{github.repository_owner}}/nrn
           # Init submodules for testing purposes
-          cd nrn && git submodule update --init
+          cd nrn && git submodule update --init --recursive
 
       # When we run in Ubuntu/Fedora/Debian containers from Docker Hub then we
       # are root. This is different from when we use the GitHub Actions images

--- a/.github/workflows/build-neuron.yml
+++ b/.github/workflows/build-neuron.yml
@@ -2,6 +2,9 @@ name: Scheduled NEURON CI
 
 on:
   push:
+    branches:
+      - main
+  pull_request:
   schedule:
     # Run at 2am every day
     - cron:  '0 2 * * *'
@@ -44,10 +47,10 @@ jobs:
         then
           # If we're not told to test a specific branch, test the default branch with neuron-nightly wheels
           values="{\"branch_or_tag\": \"\", \"default_wheel\": \"neuron-nightly\"}"
-          if [[ $(date +%u) == 1 ]] || [[ ${{ github.event_name }} == 'pull_request' ]]
+          if [[ $(date +%u) == 1 ]] || [[ ${{ github.event_name }} == 'pull_request' ]] || [[ ${{ github.event_name }} == 'push' ]]
           then
             # If it's a Monday, test the latest release (and latest released wheels) in addition
-            # Also test it on any PR
+            # Also test it on any PR, and any push to a PR
             tag_name="${{steps.get_latest_release.outputs.tag_name}}"
             values="${values}, {\"branch_or_tag\": \"${tag_name}\", \"default_wheel\": \"neuron==${tag_name}\"}"
           fi

--- a/scripts/buildNeuron.sh
+++ b/scripts/buildNeuron.sh
@@ -26,7 +26,11 @@ export PYTHONPATH=$(${PYTHON} -c 'import site; print(":".join(site.getsitepackag
 
 # Install extra dependencies for NEURON into the virtual environment.
 pip install --upgrade -r nrn_requirements.txt
-pip install --upgrade -r ci_requirements.txt
+if [[ -f ci_requirements.txt ]]; then
+  pip install --upgrade -r ci_requirements.txt
+else
+  pip install --upgrade plotly "ipywidgets>=7.0.0"
+fi
 
 # Set default compilers, but don't override preset values
 export CC=${CC:-gcc}

--- a/scripts/buildNeuron.sh
+++ b/scripts/buildNeuron.sh
@@ -34,6 +34,8 @@ fi
 if [[ -f external/nmodl/requirements.txt ]]; then
   pip install --upgrade -r external/nmodl/requirements.txt
 fi
+# Needed for installation of older NEURON versions with Python 12
+pip install --upgrade setuptools
 
 # Set default compilers, but don't override preset values
 export CC=${CC:-gcc}

--- a/scripts/buildNeuron.sh
+++ b/scripts/buildNeuron.sh
@@ -25,8 +25,8 @@ export PYTHON=$(command -v python)
 export PYTHONPATH=$(${PYTHON} -c 'import site; print(":".join(site.getsitepackages()))')
 
 # Install extra dependencies for NEURON into the virtual environment.
-pip install --upgrade bokeh "cython<3" ipython matplotlib mpi4py numpy pytest \
-  pytest-cov scikit-build sympy
+pip install --upgrade -r nrn_requirements.txt
+pip install --upgrade -r ci_requirements.txt
 
 # Set default compilers, but don't override preset values
 export CC=${CC:-gcc}

--- a/scripts/buildNeuron.sh
+++ b/scripts/buildNeuron.sh
@@ -31,6 +31,9 @@ if [[ -f ci_requirements.txt ]]; then
 else
   pip install --upgrade plotly "ipywidgets>=7.0.0"
 fi
+if [[ -f external/nmodl/requirements.txt ]]; then
+  pip install --upgrade -r external/nmodl/requirements.txt
+fi
 
 # Set default compilers, but don't override preset values
 export CC=${CC:-gcc}

--- a/scripts/install_macOS.sh
+++ b/scripts/install_macOS.sh
@@ -1,3 +1,6 @@
+set -eux
+export HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1
+export HOMEBREW_NO_INSTALL_UPGRADE=1
 brew install bison boost coreutils flex mpich ninja xz wget
 brew unlink mpich
 brew install openmpi


### PR DESCRIPTION
- Use `nrn_requirements.txt` and `ci_requirements.txt` to install the necessary python packages for the NEURON installation
- If `ci_requirements.txt` doesn't exist (NEURON 8.2.3) then just install the current packages listed in it
- Install the NMODL required packages from `external/nmodl/requirements.txt`
- Upgrade from MacOS 11,12 to 12, 13
- Install `setuptools` for `Python 12` support
- Recursively clone submodules

## TODO

- [x] Port https://github.com/neuronsimulator/nrn/pull/2193 to `NEURON 8.2.3` to enable Python 3.12 support (handled in https://github.com/neuronsimulator/nrn/pull/2663)
- [x] fix segfault in Python 3.12 (fixed in https://github.com/neuronsimulator/nrn/pull/2695)