### PR TITLE
Increase time for CI

### DIFF
--- a/.github/workflows/build-neuron.yml
+++ b/.github/workflows/build-neuron.yml
@@ -63,7 +63,7 @@ jobs:
       matrix: ${{ steps.provide_versions.outputs.matrix }}
 
   ci:
-    timeout-minutes: 45
+    timeout-minutes: 60
     needs: provide_version_matrix
     runs-on: ${{ matrix.os.vm }}
     container: ${{ matrix.os.container }}


### PR DESCRIPTION
The MacOS 12 CI is very slow for some reason, and needs more time to run the tests sometimes.