### PR TITLE
Fix for Fedora latest

### DIFF
--- a/scripts/environment_redhat.sh
+++ b/scripts/environment_redhat.sh
@@ -4,7 +4,9 @@
 # ---
 # This is working around GitHub Actions running commands in non-login shells
 # that would otherwise not have the `module` command available.
+set +e
 source /etc/profile.d/modules.sh
+set -e
 # ---
 # --- End GitHub-Actions-specific code ---
 # ---


### PR DESCRIPTION
One of the init scripts in the latest version of LMOD doesn't handle `-e` mode properly, so as a fix we temporarily turn it off when using it.