### PR TITLE
Pin Python to 3.12 on Fedora latest

### DIFF
--- a/.github/workflows/build-neuron.yml
+++ b/.github/workflows/build-neuron.yml
@@ -130,7 +130,7 @@ jobs:
         env:
           FLAVOUR_SCRIPT: scripts/install_${{matrix.os.flavour}}.sh
 
-      - if: ${{matrix.os.flavour}} == 'macOS'
+      - if: ${{matrix.os.flavour}} == 'macOS' || ${{matrix.os.container}} == 'fedora:latest'
         name: Set up Python@${{ env.MACOSX_PY_VERSION }}
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/build-neuron.yml
+++ b/.github/workflows/build-neuron.yml
@@ -136,6 +136,10 @@ jobs:
         with:
           python-version: ${{ env.MACOSX_PY_VERSION }}
 
+      - if: ${{matrix.os.container}} == 'fedora:latest'
+        name: Set NRN_PYTHON
+        run: echo "NRN_PYTHON=$(command -v python3)" >> "${GITHUB_ENV}"
+
       # Checkout the repository; do this before the privilege step so that we
       # can chown the result there
       - name: Checkout NEURON

--- a/.github/workflows/build-neuron.yml
+++ b/.github/workflows/build-neuron.yml
@@ -138,7 +138,9 @@ jobs:
 
       - if: ${{ matrix.os.container && matrix.os.container == 'fedora:latest' }}
         name: Set NRN_PYTHON
-        run: echo "NRN_PYTHON=$(command -v python3)" >> "${GITHUB_ENV}"
+        run: |
+          echo "NRN_PYTHON=$(command -v python3)" >> "${GITHUB_ENV}"
+          echo "LD_LIBRARY_PATH=${LD_LIBRARY_PATH}" >> "${GITHUB_ENV}"
 
       # Checkout the repository; do this before the privilege step so that we
       # can chown the result there

--- a/.github/workflows/build-neuron.yml
+++ b/.github/workflows/build-neuron.yml
@@ -136,7 +136,7 @@ jobs:
         with:
           python-version: ${{ env.MACOSX_PY_VERSION }}
 
-      - if: ${{matrix.os.container}} == 'fedora:latest'
+      - if: ${{ matrix.os.container && matrix.os.container == 'fedora:latest' }}
         name: Set NRN_PYTHON
         run: echo "NRN_PYTHON=$(command -v python3)" >> "${GITHUB_ENV}"
 

--- a/scripts/buildNeuron.sh
+++ b/scripts/buildNeuron.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -x
 # Set up the runtime environment by sourcing the environmentXXX.sh scripts.
 # For a local installation you might have put the content of those scripts
 # directly into your ~/.bashrc or ~/.zshrc

--- a/scripts/environment.sh
+++ b/scripts/environment.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -x
 # Set up the runtime environment by sourcing the environmentXXX.sh scripts in
 # the same directory as this script.
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"

--- a/scripts/environment_redhat_fedora_latest.sh
+++ b/scripts/environment_redhat_fedora_latest.sh
@@ -1,3 +1,4 @@
 # Inspired by https://github.com/open-mpi/ompi/issues/11295 to try and
 # avoid hangs when running MPI tests.
+set -x
 export FI_PROVIDER="tcp"


### PR DESCRIPTION
Fedora latest comes with Python 3.13, which we don't support yet, so we need to pin Python to some other version (in this case, 3.12).