### PR TITLE
Remove MacOS 12 from CI

### DIFF
--- a/.github/workflows/build-neuron.yml
+++ b/.github/workflows/build-neuron.yml
@@ -82,8 +82,6 @@ jobs:
         os:
         # GitHub Actions MacOS 13 runner
         - { vm: macos-13, flavour: macOS }
-        # GitHub Actions MacOS 12 runner
-        - { vm: macos-12, flavour: macOS }
         # Alma Linux 8 Docker image
         - { vm: ubuntu-latest, container: "almalinux:8.10", flavour: redhat }
         # CentOS Stream 9 Docker image


### PR DESCRIPTION
As per https://github.com/actions/runner-images/issues/10721, it will permanently be removed on 2024-12-03.