### PR TITLE
Fixes for Python min and max versions

### DIFF
--- a/.github/workflows/build-neuron.yml
+++ b/.github/workflows/build-neuron.yml
@@ -131,7 +131,7 @@ jobs:
           FLAVOUR_SCRIPT: scripts/install_${{matrix.os.flavour}}.sh
 
       # MacOS has 3.13 as default, so we instead install the max supported one
-      - if: ${{matrix.os.flavour}} == 'macOS'
+      - if: startsWith(matrix.os.flavour, 'macOS')
         name: Set up Python@${{ env.MAX_PYTHON_VERSION }}
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/build-neuron.yml
+++ b/.github/workflows/build-neuron.yml
@@ -72,12 +72,10 @@ jobs:
       SDK_ROOT: $(xcrun --sdk macosx --show-sdk-path)
       OS_FLAVOUR: ${{matrix.os.flavour}}
       # min minor supported version of Python
-      MIN_PYTHON_VERSION: '9'
+      MIN_MINOR_PYTHON_VERSION: '9'
       # max minor supported version of Python
-      MAX_PYTHON_VERSION: '12'
+      MAX_MINOR_PYTHON_VERSION: '12'
       UNPRIVILEGED_USER: runner # User created+used inside Docker containers
-      # Extra software collections to be installed and enabled on CentOS7
-      SOFTWARE_COLLECTIONS_centos_7: devtoolset-9 rh-git218 rh-python38
 
     strategy:
       matrix:
@@ -132,10 +130,10 @@ jobs:
 
       # MacOS has 3.13 as default, so we instead install the max supported one
       - if: startsWith(matrix.os.flavour, 'macOS')
-        name: Set up Python@${{ env.MAX_PYTHON_VERSION }}
+        name: Set up Python@3.${{ env.MAX_MINOR_PYTHON_VERSION }}
         uses: actions/setup-python@v5
         with:
-          python-version: "3.${{ env.MAX_PYTHON_VERSION }}"
+          python-version: "3.${{ env.MAX_MINOR_PYTHON_VERSION }}"
 
       # Checkout the repository; do this before the privilege step so that we
       # can chown the result there

--- a/.github/workflows/build-neuron.yml
+++ b/.github/workflows/build-neuron.yml
@@ -76,6 +76,8 @@ jobs:
       # max minor supported version of Python
       MAX_PYTHON_VERSION: '12'
       UNPRIVILEGED_USER: runner # User created+used inside Docker containers
+      # Extra software collections to be installed and enabled on CentOS7
+      SOFTWARE_COLLECTIONS_centos_7: devtoolset-9 rh-git218 rh-python38
 
     strategy:
       matrix:

--- a/.github/workflows/build-neuron.yml
+++ b/.github/workflows/build-neuron.yml
@@ -71,11 +71,11 @@ jobs:
     env:
       SDK_ROOT: $(xcrun --sdk macosx --show-sdk-path)
       OS_FLAVOUR: ${{matrix.os.flavour}}
-      # version of Python we will build NEURON with on MacOS
-      MACOSX_PY_VERSION: 3.12
+      # min minor supported version of Python
+      MIN_PYTHON_VERSION: '9'
+      # max minor supported version of Python
+      MAX_PYTHON_VERSION: '12'
       UNPRIVILEGED_USER: runner # User created+used inside Docker containers
-      # Extra software collections to be installed and enabled on CentOS7
-      SOFTWARE_COLLECTIONS_centos_7: devtoolset-9 rh-git218 rh-python38
 
     strategy:
       matrix:
@@ -92,7 +92,7 @@ jobs:
         - { vm: ubuntu-latest, container: "fedora:40", flavour: redhat }
         # Ubuntu 20.04 Docker image
         - { vm: ubuntu-latest, container: "ubuntu:20.04", flavour: debian }
-        # Ubuntu Latest (22.04, at time of writing) Docker image
+        # Ubuntu Latest (24.04, at time of writing) Docker image
         - { vm: ubuntu-latest, container: "ubuntu:latest", flavour: debian }
         # Debian Bullseye (11) Docker image
         - { vm: ubuntu-latest, container: "debian:bullseye", flavour: debian }
@@ -128,11 +128,12 @@ jobs:
         env:
           FLAVOUR_SCRIPT: scripts/install_${{matrix.os.flavour}}.sh
 
+      # MacOS has 3.13 as default, so we instead install the max supported one
       - if: ${{matrix.os.flavour}} == 'macOS'
-        name: Set up Python@${{ env.MACOSX_PY_VERSION }}
+        name: Set up Python@${{ env.MAX_PYTHON_VERSION }}
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ env.MACOSX_PY_VERSION }}
+          python-version: "3.${{ env.MAX_PYTHON_VERSION }}"
 
       # Checkout the repository; do this before the privilege step so that we
       # can chown the result there

--- a/scripts/environment_macOS.sh
+++ b/scripts/environment_macOS.sh
@@ -4,6 +4,7 @@ export SKIP_EMBEDED_PYTHON_TEST=true
 # Do not enable OpenMP on macOS
 export CORENRN_ENABLE_OPENMP=OFF
 # Use Bison from homebrew
-export PATH=/usr/local/opt/bison/bin:${PATH}
+PATH="$(brew --prefix)/opt/bison/bin:${PATH}"
 # Use Flex from homebrew
-export PATH=/usr/local/opt/flex/bin:${PATH}
+PATH="$(brew --prefix)/opt/flex/bin:${PATH}"
+export PATH

--- a/scripts/install_debian.sh
+++ b/scripts/install_debian.sh
@@ -22,7 +22,7 @@ if [[ -z "${NRN_PYTHON}" ]]; then
       # install min supported Python version from external repo
       apt-get install -y software-properties-common
       add-apt-repository -y ppa:deadsnakes/ppa
-      apt-get install -y "python3.${MIN_PYTHON_VERSION}"
+      apt-get install -y "python3.${MIN_PYTHON_VERSION}-dev" "python3.${MIN_PYTHON_VERSION}-venv"
       NRN_PYTHON="$(command -v "python3.${MIN_PYTHON_VERSION}")"
       export NRN_PYTHON
   elif [[ "${python_version}" -gt "${MAX_PYTHON_VERSION}" ]]

--- a/scripts/install_debian.sh
+++ b/scripts/install_debian.sh
@@ -14,7 +14,7 @@ apt-get install -y bison cmake flex git libncurses-dev libmpich-dev libssl-dev \
 if [[ "${DO_NOT_INSTALL_BOOST:-false}" != "true" ]]; then
   apt-get install -y libboost-all-dev
 fi
-if [[ -z "${NRN_PYTHON}" ]]; then
+if [[ -z "${NRN_PYTHON:-}" ]]; then
   apt-get install -y python3-dev python3-venv
 
   python_minor_version="$(python3 -c 'import sys;print(sys.version_info.minor)')"

--- a/scripts/install_debian.sh
+++ b/scripts/install_debian.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -eu
 # ---
 # --- Begin GitHub-Actions-specific code ---
 # ---
@@ -16,20 +17,20 @@ fi
 if [[ -z "${NRN_PYTHON}" ]]; then
   apt-get install -y python3-dev python3-venv
 
-  python_version="$(python3 -c 'import sys;print(sys.version_info.minor)')"
-  if [[ "${python_version}" -lt "${MIN_PYTHON_VERSION}" ]]
+  python_minor_version="$(python3 -c 'import sys;print(sys.version_info.minor)')"
+  if [[ "${python_minor_version}" -lt "${MIN_MINOR_PYTHON_VERSION}" ]]
   then
       # install min supported Python version from external repo
       apt-get install -y software-properties-common
       add-apt-repository -y ppa:deadsnakes/ppa
-      apt-get install -y "python3.${MIN_PYTHON_VERSION}-dev" "python3.${MIN_PYTHON_VERSION}-venv"
-      NRN_PYTHON="$(command -v "python3.${MIN_PYTHON_VERSION}")"
+      apt-get install -y "python3.${MIN_MINOR_PYTHON_VERSION}-dev" "python3.${MIN_MINOR_PYTHON_VERSION}-venv"
+      NRN_PYTHON="$(command -v "python3.${MIN_MINOR_PYTHON_VERSION}")"
       export NRN_PYTHON
-  elif [[ "${python_version}" -gt "${MAX_PYTHON_VERSION}" ]]
+  elif [[ "${python_minor_version}" -gt "${MAX_MINOR_PYTHON_VERSION}" ]]
   then
       # we do not want to downgrade the default version (this is _very_ unlikely to happen on Ubuntu/Debian though)
-      printf "Distribution %s comes with a version of Python that is too new (%s) for NEURON\n" "$(cat /etc/lsb-release)" "3.${python_version}"
-      printf "Please downgrade it to at most Python %s\n" "3.${python_version}"
+      printf "Distribution %s comes with a version of Python that is too new (%s) for NEURON\n" "$(cat /etc/lsb-release)" "3.${python_minor_version}"
+      printf "Please downgrade it to at most Python %s\n" "3.${MAX_MINOR_PYTHON_VERSION}"
       exit 1
   else
       NRN_PYTHON="$(command -v python3)"

--- a/scripts/install_debian.sh
+++ b/scripts/install_debian.sh
@@ -11,7 +11,7 @@ export DEBIAN_FRONTEND=noninteractive
 apt-get update
 apt-get install -y bison cmake flex git libncurses-dev libmpich-dev libssl-dev \
   libx11-dev libxcomposite-dev ninja-build mpich libreadline-dev sudo wget unzip
-if [[ "${DO_NOT_INSTALL_BOOST}" != "true" ]]; then
+if [[ "${DO_NOT_INSTALL_BOOST:-false}" != "true" ]]; then
   apt-get install -y libboost-all-dev
 fi
 if [[ -z "${NRN_PYTHON}" ]]; then

--- a/scripts/install_redhat.sh
+++ b/scripts/install_redhat.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -eu
 # Use DNF if available (not CentOS7), otherwise YUM
 CMD=$(command -v dnf || command -v yum)
 

--- a/scripts/install_redhat_almalinux_8_10.sh
+++ b/scripts/install_redhat_almalinux_8_10.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
+set -eu
 # Enable the (official) PowerTools repository. This provides Ninja.
-dnf install -y dnf-plugins-core "python3${MIN_PYTHON_VERSION}-devel" gcc-toolset-9-gcc gcc-toolset-9-gcc-c++
-NRN_PYTHON="$(command -v "python3.${MIN_PYTHON_VERSION}")"
+dnf install -y dnf-plugins-core "python3${MIN_MINOR_PYTHON_VERSION}-devel" gcc-toolset-9-gcc gcc-toolset-9-gcc-c++
+NRN_PYTHON="$(command -v "python3.${MIN_MINOR_PYTHON_VERSION}")"
 export NRN_PYTHON
 echo "NRN_PYTHON=${NRN_PYTHON}" >> $GITHUB_ENV
 dnf config-manager --set-enabled powertools

--- a/scripts/install_redhat_almalinux_8_10.sh
+++ b/scripts/install_redhat_almalinux_8_10.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -eux
 # Enable the (official) PowerTools repository. This provides Ninja.
 dnf install -y dnf-plugins-core "python3${PYTHON_MIN_VERSION}-devel" gcc-toolset-9-gcc gcc-toolset-9-gcc-c++
 NRN_PYTHON="$(command -v "python3.${PYTHON_MIN_VERSION}")"

--- a/scripts/install_redhat_almalinux_8_10.sh
+++ b/scripts/install_redhat_almalinux_8_10.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # Enable the (official) PowerTools repository. This provides Ninja.
-dnf install -y dnf-plugins-core python38-devel gcc-toolset-9-gcc gcc-toolset-9-gcc-c++
-export NRN_PYTHON=$(command -v python3.8)
+dnf install -y dnf-plugins-core "python3${PYTHON_MIN_VERSION}-devel" gcc-toolset-9-gcc gcc-toolset-9-gcc-c++
+NRN_PYTHON="$(command -v "python3.${PYTHON_MIN_VERSION}")"
+export NRN_PYTHON
 echo "NRN_PYTHON=${NRN_PYTHON}" >> $GITHUB_ENV
 dnf config-manager --set-enabled powertools

--- a/scripts/install_redhat_almalinux_8_10.sh
+++ b/scripts/install_redhat_almalinux_8_10.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
-set -eux
 # Enable the (official) PowerTools repository. This provides Ninja.
-dnf install -y dnf-plugins-core "python3${PYTHON_MIN_VERSION}-devel" gcc-toolset-9-gcc gcc-toolset-9-gcc-c++
-NRN_PYTHON="$(command -v "python3.${PYTHON_MIN_VERSION}")"
+dnf install -y dnf-plugins-core "python3${MIN_PYTHON_VERSION}-devel" gcc-toolset-9-gcc gcc-toolset-9-gcc-c++
+NRN_PYTHON="$(command -v "python3.${MIN_PYTHON_VERSION}")"
 export NRN_PYTHON
 echo "NRN_PYTHON=${NRN_PYTHON}" >> $GITHUB_ENV
 dnf config-manager --set-enabled powertools

--- a/scripts/install_redhat_centos_stream9.sh
+++ b/scripts/install_redhat_centos_stream9.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -eu
 # Enable the (official) CRB repository. This provides Ninja.
 dnf install -y dnf-plugins-core
 dnf config-manager --set-enabled crb


### PR DESCRIPTION
We removed Python 3.8 in https://github.com/neuronsimulator/nrn/pull/3108, so AlmaLinux and Ubuntu 20.04 started failing. To remedy this, on AlmaLinux we install 3.9 (available in default repos), and on Ubuntu we add another repo which has 3.9.
 
Also added better error handling (should now notify us if variables are missing or similar problems), and removed some unused env vars.