### PR TITLE
Less verbose ctest output

### DIFF
--- a/scripts/buildNeuron.sh
+++ b/scripts/buildNeuron.sh
@@ -80,4 +80,4 @@ echo "------- Install NEURON -------"
 cmake --build . -- install
 
 echo "------- Run test suite -------"
-ctest -VV -j ${PARALLEL_JOBS}
+ctest --output-on-failure -j ${PARALLEL_JOBS}


### PR DESCRIPTION
Currently the output of `ctest -VV` has over 100000 lines, making it nigh impossible to figure out which test has failed (some of them are expected to fail, so NEURON outputs `failed` on stdout/stderr, and greping becomes useless). Using only `--output-on-failure` should cut down on the noise.