### PR TITLE
Bump Ubuntu from 20.04 to 22.04

### DIFF
--- a/.github/workflows/build-neuron-template.yml
+++ b/.github/workflows/build-neuron-template.yml
@@ -90,8 +90,8 @@ jobs:
         - { vm: ubuntu-latest, container: "fedora:37", flavour: redhat }
         # Fedora 40 Docker image
         - { vm: ubuntu-latest, container: "fedora:40", flavour: redhat }
-        # Ubuntu 20.04 Docker image
-        - { vm: ubuntu-latest, container: "ubuntu:20.04", flavour: debian }
+        # Ubuntu 22.04 Docker image
+        - { vm: ubuntu-latest, container: "ubuntu:22.04", flavour: debian }
         # Ubuntu Latest (24.04, at time of writing) Docker image
         - { vm: ubuntu-latest, container: "ubuntu:latest", flavour: debian }
         # Debian Bullseye (11) Docker image

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This repository hosts [scheduled GitHub Actions workflows](.github/workflows/neu
 The default branch of NEURON (and `neuron-nightly` wheel) is tested every night,
 and the latest tagged release (and corresponding `neuron` wheel) is tested once
 a week.
-At present, Ubuntu 20.04, Ubuntu 24.04, Fedora 37, Fedora 40, CentOS Stream
+At present, Ubuntu 22.04, Ubuntu 24.04, Fedora 37, Fedora 40, CentOS Stream
 9, Alma Linux 8, Debian Bullseye (11), Debian Bookworm (12), macOS 12 and
 macOS 13 are tested.
 


### PR DESCRIPTION
20.04 will reach EOL on 2025-05-31:
https://ubuntu.com/blog/ubuntu-20-04-eol-for-devicesional