### PR TITLE
Help get release/9.0.rc2 to work with NEURON Release workflow

### DIFF
--- a/.github/workflows/build-neuron-template.yml
+++ b/.github/workflows/build-neuron-template.yml
@@ -98,7 +98,7 @@ jobs:
       # min minor supported version of Python
       MIN_MINOR_PYTHON_VERSION: '9'
       # max minor supported version of Python
-      MAX_MINOR_PYTHON_VERSION: '13'
+      MAX_MINOR_PYTHON_VERSION: '14'
       UNPRIVILEGED_USER: runner # User created+used inside Docker containers
 
     strategy:


### PR DESCRIPTION
  - Bump MAX_MINOR_PYTHON_VERSION to 14