### PR TITLE
CI: use Python 3.11 on AlmaLinux 8 and CentOS Stream 9

### DIFF
--- a/.github/workflows/build-neuron-template.yml
+++ b/.github/workflows/build-neuron-template.yml
@@ -95,8 +95,8 @@ jobs:
     env:
       SDK_ROOT: $(xcrun --sdk macosx --show-sdk-path)
       OS_FLAVOUR: ${{matrix.os.flavour}}
-      # min minor supported version of Python
-      MIN_MINOR_PYTHON_VERSION: '9'
+      # min minor supported version of Python (NEURON requires >= 3.10)
+      MIN_MINOR_PYTHON_VERSION: '10'
       # max minor supported version of Python
       MAX_MINOR_PYTHON_VERSION: '14'
       UNPRIVILEGED_USER: runner # User created+used inside Docker containers

--- a/README.md
+++ b/README.md
@@ -5,9 +5,15 @@ This repository hosts [scheduled GitHub Actions workflows](.github/workflows/neu
 The default branch of NEURON (and `neuron-nightly` wheel) is tested every night,
 and the latest tagged release (and corresponding `neuron` wheel) is tested once
 a week.
-At present, Ubuntu 22.04, Ubuntu 24.04, Fedora 37, Fedora 40, CentOS Stream
-9, Alma Linux 8, Debian Bullseye (11), Debian Bookworm (12), macOS 12 and
-macOS 13 are tested.
+At present, Ubuntu 22.04, Ubuntu 24.04, Fedora 37, Fedora 42, CentOS Stream
+9, Alma Linux 8, Debian Bookworm (12), Debian stable, and macOS 15 are among
+the platforms tested (see the workflow matrix for the live list).
+
+NEURON requires **Python ≥ 3.10**. On AlmaLinux 8 and CentOS Stream 9 the
+default `python3` is still 3.9, so the install scripts install **Python 3.11**
+(`python3.11` / `python3.11-devel`; AlmaLinux also enables EPEL) and set
+`NRN_PYTHON` accordingly.
+
 
 The tested distributions are generally configured with the explicit
 name/version of the second-newest version of the distribution at the time,

--- a/scripts/buildNeuron.sh
+++ b/scripts/buildNeuron.sh
@@ -67,9 +67,13 @@ cmake --version
 ${PYTHON} -c 'import os, sys; os.set_blocking(sys.stdout.fileno(), True)'
 
 echo "------- Configuring NEURON -------"
+# Pass both Python_EXECUTABLE (FindPython) and PYTHON_EXECUTABLE (legacy /
+# PythonHelper) so platforms whose /usr/bin/python3 is still 3.9 still configure
+# when NRN_PYTHON points at 3.10+.
 export CMAKE_OPTION="-G Ninja \
  -DNRN_ENABLE_MPI=ON -DNRN_ENABLE_INTERVIEWS=ON \
- -DNRN_ENABLE_CORENEURON=ON -DPYTHON_EXECUTABLE=${PYTHON} \
+ -DNRN_ENABLE_CORENEURON=ON \
+ -DPython_EXECUTABLE=${PYTHON} -DPYTHON_EXECUTABLE=${PYTHON} \
  -DCMAKE_C_COMPILER=${CC} -DCMAKE_CXX_COMPILER=${CXX} \
  -DNRN_ENABLE_TESTS=ON -DCMAKE_INSTALL_PREFIX=${INSTALL_DIR} \
  -DCORENRN_ENABLE_OPENMP=${CORENRN_ENABLE_OPENMP:-ON}"

--- a/scripts/install_redhat_almalinux_8_10.sh
+++ b/scripts/install_redhat_almalinux_8_10.sh
@@ -1,8 +1,11 @@
 #!/bin/bash
 set -eu
 # Enable the (official) PowerTools repository. This provides Ninja.
-dnf install -y dnf-plugins-core "python3${MIN_MINOR_PYTHON_VERSION}-devel" gcc-toolset-9-gcc gcc-toolset-9-gcc-c++
-NRN_PYTHON="$(command -v "python3.${MIN_MINOR_PYTHON_VERSION}")"
+dnf install -y dnf-plugins-core epel-release
+dnf config-manager --set-enabled powertools
+# AlmaLinux 8 AppStream modules only go up to Python 3.9; NEURON needs >= 3.10.
+# EPEL provides python3.11 (package name uses a dot: python3.11-devel).
+dnf install -y python3.11 python3.11-devel gcc-toolset-9-gcc gcc-toolset-9-gcc-c++
+NRN_PYTHON="$(command -v python3.11)"
 export NRN_PYTHON
 echo "NRN_PYTHON=${NRN_PYTHON}" >> $GITHUB_ENV
-dnf config-manager --set-enabled powertools

--- a/scripts/install_redhat_centos_stream9.sh
+++ b/scripts/install_redhat_centos_stream9.sh
@@ -3,3 +3,9 @@ set -eu
 # Enable the (official) CRB repository. This provides Ninja.
 dnf install -y dnf-plugins-core
 dnf config-manager --set-enabled crb
+# CentOS Stream 9 default python3 is 3.9; NEURON needs >= 3.10.
+# AppStream provides python3.11.
+dnf install -y python3.11 python3.11-devel
+NRN_PYTHON="$(command -v python3.11)"
+export NRN_PYTHON
+echo "NRN_PYTHON=${NRN_PYTHON}" >> $GITHUB_ENV


### PR DESCRIPTION
NEURON requires Python >= 3.10. Those images still ship python3 as 3.9, so install python3.11-devel (EPEL on AlmaLinux), set NRN_PYTHON, bump MIN_MINOR_PYTHON_VERSION to 10, and pass Python_EXECUTABLE to CMake.